### PR TITLE
[I-5] Extra cloning strategy documented

### DIFF
--- a/src/Catapultar.sol
+++ b/src/Catapultar.sol
@@ -40,9 +40,9 @@ import { LibCalls } from "./libs/LibCalls.sol";
  *
  * Additionally, as an account it can be initialised with a call that anyone can make.
  *
- * The contract is intended to be used via 3 cloning strategies:
+ * The contract is intended to be used via two cloning strategies:
  * - Non-upgradeable minimal proxy clone for minimal cost.
- * - Upgradeable proxy to allow ownership handover.
+ * - Upgradeable proxy to allow implementation upgrades, new features, or bug fixes.
  *
  * For ERC-1271 signatures verified from the owner, they should be rehashed in a replay protection envelope:
  * keccak256(

--- a/src/CatapultarFactory.sol
+++ b/src/CatapultarFactory.sol
@@ -11,9 +11,8 @@ import { Catapultar } from "./Catapultar.sol";
  * @custom:version 0.0.1
  * @notice Facilitates the deployment of clones of Catapultar.
  *
- * Three cloning strategies are supported:
+ * Two cloning strategies are supported:
  * - Non-upgradeable minimal PUSH_0 clone for a low cost batch execution account.
- * - Non-upgradeable embedded args clone for a short lived account with a pre-configured allowed call.
  * - Upgradeable ERC1967 proxy for a durable long term account.
  *
  * After the proxy has been deployed, init is called to set the owner.


### PR DESCRIPTION
Not all documentation was cleaned of references to a depreciated cloning strategy. This PR resolves that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contract documentation to reflect two supported cloning strategies and clarified upgrade behavior descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->