### PR TITLE
[I-4] Calls struct has different order than `CALLS_TYPE_HASH`

### DIFF
--- a/src/libs/LibCalls.sol
+++ b/src/libs/LibCalls.sol
@@ -5,8 +5,8 @@ import { ERC7821 } from "solady/src/accounts/ERC7821.sol";
 import { EfficientHashLib } from "solady/src/utils/EfficientHashLib.sol";
 
 struct Calls {
-    bytes32 mode;
     uint256 nonce;
+    bytes32 mode;
     ERC7821.Call[] calls;
 }
 


### PR DESCRIPTION
Reorder the `Calls` structure to match the typehash. New struct:

```solidity
struct Calls {
  uint256 nonce;
  bytes32 mode;
  ERC7821.Call[] calls;
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized data structure field ordering for improved code organization without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->