### PR TITLE
[I-3] Incorrect documented byte range

### DIFF
--- a/src/libs/ERC7821LIFI.sol
+++ b/src/libs/ERC7821LIFI.sol
@@ -72,8 +72,8 @@ abstract contract ERC7821LIFI is ERC7821 {
 
     // extraData has the following format:
     // [0] revert flag
-    // [1 .. 22] Nonce extract
-    // [23 .. 31] Index
+    // [1 .. 23] Nonce extract
+    // [24 .. 31] Index
 
     /**
      * @notice Executes the provides calls after validating opData


### PR DESCRIPTION
Correctly document the exposed nonce in the extraData of `CallReverted` event