### PR TITLE
[I-1] Incorrect padded length comment

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,7 @@ via_ir = true
 solc_version = "0.8.30"
 optimizer = true
 optimizer_runs = 100_000_000
+bytecode_hash = 'none'
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
 

--- a/src/libs/ERC7821LIFI.sol
+++ b/src/libs/ERC7821LIFI.sol
@@ -148,12 +148,12 @@ abstract contract ERC7821LIFI is ERC7821 {
             if iszero(success) {
                 mstore(m, extraData) // Place extraData
                 mstore(add(m, 0x20), 0x40) // Set offset for bytes
-                    // Compute the padded length for ABI alignment. (rdsize + rdsize % 32)
+                // Compute the padded length for ABI alignment. ((rdsize + 31) / 32 * 32)
                 let sizeAfterPad := and(add(returndatasize(), 31), not(31))
                 mstore(add(add(m, 0x40), sizeAfterPad), 0) // Clear out potential overflowing returndata.
                 mstore(add(m, 0x40), returndatasize()) // Place length of returndata
                 returndatacopy(add(m, 0x60), 0x00, returndatasize()) // Place returndata
-                    // Emit CallReverted(bytes32 extraData, bytes revertData).
+                // Emit CallReverted(bytes32 extraData, bytes revertData).
                 log1(m, add(0x60, sizeAfterPad), _CALL_REVERTED_EVENT_SIGNATURE)
 
                 if iszero(shr(mul(31, 8), extraData)) {


### PR DESCRIPTION
This PR correctly changes the comment related to ABI padding for the `CallReverted` event.

It also disabled the bytecode hash embedded inside Solidity contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration with new bytecode hash option for default profile settings.

* **Refactor**
  * Clarified internal code documentation for calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->