### PR TITLE
feat(intent factory): add executor contract

### DIFF
--- a/solidity/script/deploy.s.sol
+++ b/solidity/script/deploy.s.sol
@@ -5,6 +5,7 @@ import { multichain } from "./multichain.s.sol";
 
 import { CATValidator } from "../src/CATValidator.sol";
 import { CatapultarFactory } from "../src/CatapultarFactory.sol";
+import { IntentExecutor } from "../src/libs/IntentExecutor.sol";
 import { KeyedOwnable } from "../src/libs/KeyedOwnable.sol";
 
 contract deploy is multichain {
@@ -12,9 +13,15 @@ contract deploy is multichain {
 
     function run(
         string[] calldata chains
-    ) public iterChains(chains) broadcast returns (CatapultarFactory factory, CATValidator validator) {
+    )
+        public
+        iterChains(chains)
+        broadcast
+        returns (CatapultarFactory factory, CATValidator validator, IntentExecutor intentExecutor)
+    {
         factory = deployFactory();
         validator = deployCATValidator();
+        intentExecutor = deployIntentExecutor();
     }
 
     function deployFactory() internal returns (CatapultarFactory factory) {
@@ -36,11 +43,21 @@ contract deploy is multichain {
         address expectedAddress = getExpectedCreate2Address(bytes32(0), type(CATValidator).creationCode, hex"");
         if (expectedAddress.code.length == 0) {
             validator = new CATValidator{ salt: bytes32(0) }();
-            if (expectedAddress != address(validator)) {
-                revert NotExpectedAddress(expectedAddress, address(validator));
-            }
+            if (expectedAddress != address(validator)) revert NotExpectedAddress(expectedAddress, address(validator));
         }
         return CATValidator(expectedAddress);
+    }
+
+    function deployIntentExecutor() internal returns (IntentExecutor intentExecutor) {
+        address payable expectedAddress =
+            payable(getExpectedCreate2Address(bytes32(0), type(IntentExecutor).creationCode, hex""));
+        if (expectedAddress.code.length == 0) {
+            intentExecutor = new IntentExecutor{ salt: bytes32(0) }();
+            if (expectedAddress != address(intentExecutor)) {
+                revert NotExpectedAddress(expectedAddress, address(intentExecutor));
+            }
+        }
+        return IntentExecutor(expectedAddress);
     }
 
     function account(

--- a/solidity/src/libs/IntentExecutor.sol
+++ b/solidity/src/libs/IntentExecutor.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import { LibBit } from "solady/src/utils/LibBit.sol";
+import { ReentrancyGuard } from "solady/src/utils/ReentrancyGuard.sol";
+import { SafeTransferLib } from "solady/src/utils/SafeTransferLib.sol";
+
+/// @title IntentExecutor
+/// @author LI.FI / Intent Factory
+/// @notice Multicall-like execution contract for Intent Factory bundle execution.
+/// @dev Replaces Multicall3 as the execution target for IF solver.
+///      Three-phase execution:
+///      1. Safe approvals — safeApproveWithRetry(type(uint256).max) for each input token,
+///         handling USDT-style tokens that revert on non-zero-to-non-zero approve.
+///         Max approval means subsequent executions with the same token+spender
+///         skip the storage write (~3-4k gas saved per repeat).
+///      2. Call execution — arbitrary batched calls (swap, fee transfer, etc.)
+///      3. Balance sweep — reads balanceOf(this) for each output token and transfers
+///         the full remaining balance to the specified recipient.
+///
+///      This contract is stateless and designed for permissionless deployment
+///      via the Catapultar stack's CREATE2 deployment scheme.
+///
+/// @custom:version 2.0.0
+contract IntentExecutor is ReentrancyGuard {
+    /// @dev Multicall3-compatible call struct (no value)
+    struct Call3 {
+        address target;
+        bool allowFailure;
+        bytes callData;
+    }
+
+    /// @dev Multicall3-compatible call struct with value (for native transfers)
+    struct Call3Value {
+        address target;
+        bool allowFailure;
+        uint256 value;
+        bytes callData;
+    }
+
+    /// @dev Result struct matching Multicall3
+    struct Result {
+        bool success;
+        bytes returnData;
+    }
+
+    /// @dev Token + spender pair for safe max approvals
+    struct Approval {
+        address token;
+        address spender;
+    }
+
+    /// @dev Token + destination pair for post-execution sweep
+    struct SweepTarget {
+        address token;
+        address recipient;
+    }
+
+    /// Errors ///
+
+    error ZeroRecipient();
+
+    /// Events ///
+
+    event Swept(address indexed token, address indexed recipient, uint256 amount);
+    event SweptNative(address indexed recipient, uint256 amount);
+
+    /// External Methods ///
+
+    /// @notice Execute with safe approvals, batched calls, and ERC20 balance sweep.
+    /// @dev Three-phase execution:
+    ///      1. For each approval: safeApproveWithRetry(token, spender, type(uint256).max)
+    ///      2. Execute all calls in order
+    ///      3. For each sweep target: transfer full balanceOf(this) to recipient
+    /// @param approvals Token+spender pairs to max-approve before execution
+    /// @param calls Array of calls to execute (swap, fee transfer, etc.)
+    /// @param sweepTargets Token+recipient pairs to sweep after execution
+    /// @return results Array of call results
+    function executeAndSweep(
+        Approval[] calldata approvals,
+        Call3[] calldata calls,
+        SweepTarget[] calldata sweepTargets
+    ) external nonReentrant returns (Result[] memory results) {
+        _safeApproveAll(approvals);
+        results = _executeCalls(calls);
+        _sweepAll(sweepTargets);
+    }
+
+    /// @notice Execute with safe approvals, batched calls with value, and native balance sweep.
+    /// @dev Used for swaps that output native tokens (ETH/MATIC/etc).
+    /// @param approvals Token+spender pairs to max-approve before execution
+    /// @param calls Array of calls with value to execute
+    /// @param sweepTargets ERC20 token+recipient pairs to sweep after execution
+    /// @param nativeSweepRecipient Address to receive remaining native balance (zero address falls back to
+    ///     msg.sender)
+    /// @return results Array of call results
+    function executeAndSweepNative(
+        Approval[] calldata approvals,
+        Call3Value[] calldata calls,
+        SweepTarget[] calldata sweepTargets,
+        address payable nativeSweepRecipient
+    ) external payable nonReentrant returns (Result[] memory results) {
+        _safeApproveAll(approvals);
+        results = _executeCallsWithValue(calls);
+        _sweepAll(sweepTargets);
+
+        uint256 nativeBalance = address(this).balance;
+        if (nativeBalance > 0) {
+            address sweepRecipient = nativeSweepRecipient == address(0) ? msg.sender : nativeSweepRecipient;
+            SafeTransferLib.safeTransferETH(sweepRecipient, nativeBalance);
+            emit SweptNative(sweepRecipient, nativeBalance);
+        }
+    }
+
+    /// @notice Receive native ETH (required for swaps that output native tokens)
+    receive() external payable { }
+
+    /// Internal Methods ///
+
+    /// @dev Safe max-approve each token to its spender.
+    ///      Uses SafeTransferLib.safeApproveWithRetry which handles USDT-style tokens
+    ///      by resetting to 0 first if needed.
+    ///      Max approval is a one-time storage write — subsequent calls with
+    ///      the same token+spender pair are a no-op read (~3-4k gas saved).
+    function _safeApproveAll(
+        Approval[] calldata approvals
+    ) private {
+        uint256 len = approvals.length;
+        for (uint256 i = 0; i < len; ++i) {
+            SafeTransferLib.safeApproveWithRetry(approvals[i].token, approvals[i].spender, type(uint256).max);
+        }
+    }
+
+    /// @dev Transfer full remaining balance of each token to its recipient.
+    function _sweepAll(
+        SweepTarget[] calldata sweepTargets
+    ) private {
+        uint256 len = sweepTargets.length;
+        for (uint256 i = 0; i < len; ++i) {
+            SweepTarget calldata target = sweepTargets[i];
+            if (target.recipient == address(0)) revert ZeroRecipient();
+            uint256 balance = SafeTransferLib.balanceOf(target.token, address(this));
+            if (balance > 0) {
+                SafeTransferLib.safeTransfer(target.token, target.recipient, balance);
+                emit Swept(target.token, target.recipient, balance);
+            }
+        }
+    }
+
+    /// @dev Executes an array of calls without value
+    function _executeCalls(
+        Call3[] calldata calls
+    ) private returns (Result[] memory results) {
+        uint256 len = calls.length;
+        results = new Result[](len);
+        for (uint256 i = 0; i < len; ++i) {
+            Call3 calldata call3 = calls[i];
+            (bool success, bytes memory ret) = call3.target.call(call3.callData);
+            // Branchless: revert if both allowFailure=false and success=false
+            if (LibBit.and(!call3.allowFailure, !success)) {
+                assembly {
+                    revert(add(ret, 0x20), mload(ret))
+                }
+            }
+            results[i] = Result(success, ret);
+        }
+    }
+
+    /// @dev Executes an array of calls with value
+    function _executeCallsWithValue(
+        Call3Value[] calldata calls
+    ) private returns (Result[] memory results) {
+        uint256 len = calls.length;
+        results = new Result[](len);
+        for (uint256 i = 0; i < len; ++i) {
+            Call3Value calldata call3 = calls[i];
+            (bool success, bytes memory ret) = call3.target.call{ value: call3.value }(call3.callData);
+            // Branchless: revert if both allowFailure=false and success=false
+            if (LibBit.and(!call3.allowFailure, !success)) {
+                assembly {
+                    revert(add(ret, 0x20), mload(ret))
+                }
+            }
+            results[i] = Result(success, ret);
+        }
+    }
+}

--- a/solidity/test/libs/IntentExecutor.t.sol
+++ b/solidity/test/libs/IntentExecutor.t.sol
@@ -24,7 +24,7 @@ contract IntentExecutorTest is Test {
         feeCollector = makeAddr("feeCollector");
     }
 
-    // ─── executeAndSweep ────────────────────────────────────────────
+    // -- executeAndSweep --
 
     function test_executeAndSweep_sweepsFullBalance() external {
         uint256 amount = 1 ether;
@@ -119,7 +119,7 @@ contract IntentExecutorTest is Test {
         assertEq(tokenA.balanceOf(address(executor)), 0);
     }
 
-    // ─── executeAndSweepNative ──────────────────────────────────────
+    // -- executeAndSweepNative --
 
     function test_executeAndSweepNative_sweepsNativeToRecipient() external {
         uint256 amount = 1 ether;
@@ -196,7 +196,7 @@ contract IntentExecutorTest is Test {
         assertEq(recipient.balance, 1 ether);
     }
 
-    // ─── Call execution ─────────────────────────────────────────────
+    // -- Call execution --
 
     function test_callExecution_revertsOnFailedCall() external {
         IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
@@ -261,7 +261,7 @@ contract IntentExecutorTest is Test {
         assertEq(recipient.balance, amount);
     }
 
-    // ─── Sweep guards ───────────────────────────────────────────────
+    // -- Sweep guards --
 
     function testRevert_sweepToZeroAddress() external {
         tokenA.mint(address(executor), 1 ether);
@@ -275,7 +275,7 @@ contract IntentExecutorTest is Test {
         executor.executeAndSweep(approvals, calls, sweeps);
     }
 
-    // ─── Approvals ──────────────────────────────────────────────────
+    // -- Approvals --
 
     function test_approvalSetsMaxAllowance() external {
         IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](1);
@@ -308,7 +308,7 @@ contract IntentExecutorTest is Test {
         assertLt(gasUsed2, gasUsed1);
     }
 
-    // ─── Receive ────────────────────────────────────────────────────
+    // -- Receive --
 
     function test_receiveAcceptsEth() external {
         vm.deal(address(this), 1 ether);
@@ -317,7 +317,7 @@ contract IntentExecutorTest is Test {
         assertEq(address(executor).balance, 1 ether);
     }
 
-    // ─── End-to-end: approve → swap → fee → sweep ──────────────────
+    // -- End-to-end: approve, swap, fee, sweep --
 
     function test_endToEnd_approveSwapFeeSweep() external {
         uint256 inputAmount = 10 ether;
@@ -355,7 +355,7 @@ contract IntentExecutorTest is Test {
         assertEq(tokenB.balanceOf(address(executor)), 0);
     }
 
-    // ─── Helpers ────────────────────────────────────────────────────
+    // -- Helpers --
 
     receive() external payable { }
 }

--- a/solidity/test/libs/IntentExecutor.t.sol
+++ b/solidity/test/libs/IntentExecutor.t.sol
@@ -261,6 +261,21 @@ contract IntentExecutorTest is Test {
         assertEq(recipient.balance, amount);
     }
 
+    function test_callExecution_withValue_revertsOnFailedCall() external {
+        vm.deal(address(executor), 1 ether);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3Value[] memory calls = new IntentExecutor.Call3Value[](1);
+        // Send value to a contract that can't receive ETH (tokenA has no receive/fallback)
+        calls[0] = IntentExecutor.Call3Value({
+            target: address(tokenA), allowFailure: false, value: 1 ether, callData: hex""
+        });
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        vm.expectRevert();
+        executor.executeAndSweepNative{ value: 1 ether }(approvals, calls, sweeps, payable(address(0)));
+    }
+
     // -- Sweep guards --
 
     function testRevert_sweepToZeroAddress() external {

--- a/solidity/test/libs/IntentExecutor.t.sol
+++ b/solidity/test/libs/IntentExecutor.t.sol
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import { Test } from "forge-std/src/Test.sol";
+
+import { MockERC20 } from "solady/test/utils/mocks/MockERC20.sol";
+
+import { IntentExecutor } from "../../src/libs/IntentExecutor.sol";
+
+contract IntentExecutorTest is Test {
+    IntentExecutor executor;
+    MockERC20 tokenA;
+    MockERC20 tokenB;
+    address user;
+    address recipient;
+    address feeCollector;
+
+    function setUp() external {
+        executor = new IntentExecutor();
+        tokenA = new MockERC20("Token A", "TKA", 18);
+        tokenB = new MockERC20("Token B", "TKB", 18);
+        user = makeAddr("user");
+        recipient = makeAddr("recipient");
+        feeCollector = makeAddr("feeCollector");
+    }
+
+    // ─── executeAndSweep ────────────────────────────────────────────
+
+    function test_executeAndSweep_sweepsFullBalance() external {
+        uint256 amount = 1 ether;
+        tokenA.mint(address(executor), amount);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](1);
+        sweeps[0] = IntentExecutor.SweepTarget({ token: address(tokenA), recipient: recipient });
+
+        vm.expectEmit(true, true, false, true);
+        emit IntentExecutor.Swept(address(tokenA), recipient, amount);
+
+        executor.executeAndSweep(approvals, calls, sweeps);
+
+        assertEq(tokenA.balanceOf(recipient), amount);
+        assertEq(tokenA.balanceOf(address(executor)), 0);
+    }
+
+    function test_executeAndSweep_multiTokenSweep() external {
+        uint256 amountA = 1 ether;
+        uint256 amountB = 2 ether;
+        tokenA.mint(address(executor), amountA);
+        tokenB.mint(address(executor), amountB);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](2);
+        sweeps[0] = IntentExecutor.SweepTarget({ token: address(tokenA), recipient: recipient });
+        sweeps[1] = IntentExecutor.SweepTarget({ token: address(tokenB), recipient: recipient });
+
+        executor.executeAndSweep(approvals, calls, sweeps);
+
+        assertEq(tokenA.balanceOf(recipient), amountA);
+        assertEq(tokenB.balanceOf(recipient), amountB);
+        assertEq(tokenA.balanceOf(address(executor)), 0);
+        assertEq(tokenB.balanceOf(address(executor)), 0);
+    }
+
+    function test_executeAndSweep_skipsZeroBalance() external {
+        // tokenA has 0 balance — should not emit Swept
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](1);
+        sweeps[0] = IntentExecutor.SweepTarget({ token: address(tokenA), recipient: recipient });
+
+        vm.recordLogs();
+        executor.executeAndSweep(approvals, calls, sweeps);
+
+        assertEq(vm.getRecordedLogs().length, 0);
+    }
+
+    function test_executeAndSweep_approvesAndExecutesCall() external {
+        uint256 amount = 1 ether;
+        tokenA.mint(address(executor), amount);
+
+        // Approve tokenA to this test contract, then call transferFrom via executor
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](1);
+        approvals[0] = IntentExecutor.Approval({ token: address(tokenA), spender: address(this) });
+
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](1);
+        calls[0] = IntentExecutor.Call3({
+            target: address(tokenA),
+            allowFailure: false,
+            callData: abi.encodeCall(MockERC20.transfer, (feeCollector, amount / 10))
+        });
+
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](1);
+        sweeps[0] = IntentExecutor.SweepTarget({ token: address(tokenA), recipient: recipient });
+
+        executor.executeAndSweep(approvals, calls, sweeps);
+
+        assertEq(tokenA.balanceOf(feeCollector), amount / 10);
+        assertEq(tokenA.balanceOf(recipient), amount - amount / 10);
+        assertEq(tokenA.balanceOf(address(executor)), 0);
+    }
+
+    function test_fuzz_executeAndSweep_sweepsArbitraryAmount(
+        uint256 amount
+    ) external {
+        vm.assume(amount > 0);
+        tokenA.mint(address(executor), amount);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](1);
+        sweeps[0] = IntentExecutor.SweepTarget({ token: address(tokenA), recipient: recipient });
+
+        executor.executeAndSweep(approvals, calls, sweeps);
+
+        assertEq(tokenA.balanceOf(recipient), amount);
+        assertEq(tokenA.balanceOf(address(executor)), 0);
+    }
+
+    // ─── executeAndSweepNative ──────────────────────────────────────
+
+    function test_executeAndSweepNative_sweepsNativeToRecipient() external {
+        uint256 amount = 1 ether;
+        vm.deal(address(executor), amount);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3Value[] memory calls = new IntentExecutor.Call3Value[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        vm.expectEmit(true, false, false, true);
+        emit IntentExecutor.SweptNative(recipient, amount);
+
+        executor.executeAndSweepNative(approvals, calls, sweeps, payable(recipient));
+
+        assertEq(recipient.balance, amount);
+        assertEq(address(executor).balance, 0);
+    }
+
+    function test_executeAndSweepNative_fallsBackToMsgSender() external {
+        uint256 amount = 1 ether;
+        vm.deal(address(executor), amount);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3Value[] memory calls = new IntentExecutor.Call3Value[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        uint256 callerBalanceBefore = address(this).balance;
+
+        executor.executeAndSweepNative(approvals, calls, sweeps, payable(address(0)));
+
+        assertEq(address(this).balance, callerBalanceBefore + amount);
+        assertEq(address(executor).balance, 0);
+    }
+
+    function test_executeAndSweepNative_sweepsBothERC20AndNative() external {
+        uint256 nativeAmount = 1 ether;
+        uint256 tokenAmount = 2 ether;
+        vm.deal(address(executor), nativeAmount);
+        tokenA.mint(address(executor), tokenAmount);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3Value[] memory calls = new IntentExecutor.Call3Value[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](1);
+        sweeps[0] = IntentExecutor.SweepTarget({ token: address(tokenA), recipient: recipient });
+
+        executor.executeAndSweepNative(approvals, calls, sweeps, payable(recipient));
+
+        assertEq(tokenA.balanceOf(recipient), tokenAmount);
+        assertEq(recipient.balance, nativeAmount);
+        assertEq(tokenA.balanceOf(address(executor)), 0);
+        assertEq(address(executor).balance, 0);
+    }
+
+    function test_executeAndSweepNative_skipsNativeSweepWhenZeroBalance() external {
+        // No native balance — should not emit SweptNative
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3Value[] memory calls = new IntentExecutor.Call3Value[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        vm.recordLogs();
+        executor.executeAndSweepNative(approvals, calls, sweeps, payable(recipient));
+
+        assertEq(vm.getRecordedLogs().length, 0);
+    }
+
+    function test_executeAndSweepNative_acceptsPayableValue() external {
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3Value[] memory calls = new IntentExecutor.Call3Value[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        vm.deal(address(this), 1 ether);
+        executor.executeAndSweepNative{ value: 1 ether }(approvals, calls, sweeps, payable(recipient));
+
+        assertEq(recipient.balance, 1 ether);
+    }
+
+    // ─── Call execution ─────────────────────────────────────────────
+
+    function test_callExecution_revertsOnFailedCall() external {
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](1);
+        calls[0] = IntentExecutor.Call3({
+            target: address(tokenA),
+            allowFailure: false,
+            callData: abi.encodeCall(MockERC20.transfer, (recipient, 999 ether)) // no balance
+         });
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        vm.expectRevert();
+        executor.executeAndSweep(approvals, calls, sweeps);
+    }
+
+    function test_callExecution_allowFailureSwallowsRevert() external {
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](1);
+        calls[0] = IntentExecutor.Call3({
+            target: address(tokenA),
+            allowFailure: true,
+            callData: abi.encodeCall(MockERC20.transfer, (recipient, 999 ether)) // no balance
+         });
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        IntentExecutor.Result[] memory results = executor.executeAndSweep(approvals, calls, sweeps);
+
+        assertEq(results.length, 1);
+        assertEq(results[0].success, false);
+    }
+
+    function test_callExecution_returnsResultsForSuccessfulCalls() external {
+        uint256 amount = 1 ether;
+        tokenA.mint(address(executor), amount);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](1);
+        calls[0] = IntentExecutor.Call3({
+            target: address(tokenA),
+            allowFailure: false,
+            callData: abi.encodeCall(MockERC20.transfer, (recipient, amount))
+        });
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        IntentExecutor.Result[] memory results = executor.executeAndSweep(approvals, calls, sweeps);
+
+        assertEq(results.length, 1);
+        assertEq(results[0].success, true);
+    }
+
+    function test_callExecution_withValue() external {
+        uint256 amount = 1 ether;
+        vm.deal(address(executor), amount);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3Value[] memory calls = new IntentExecutor.Call3Value[](1);
+        calls[0] = IntentExecutor.Call3Value({ target: recipient, allowFailure: false, value: amount, callData: hex"" });
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        executor.executeAndSweepNative(approvals, calls, sweeps, payable(address(0)));
+
+        assertEq(recipient.balance, amount);
+    }
+
+    // ─── Sweep guards ───────────────────────────────────────────────
+
+    function testRevert_sweepToZeroAddress() external {
+        tokenA.mint(address(executor), 1 ether);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](0);
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](1);
+        sweeps[0] = IntentExecutor.SweepTarget({ token: address(tokenA), recipient: address(0) });
+
+        vm.expectRevert(abi.encodeWithSelector(IntentExecutor.ZeroRecipient.selector));
+        executor.executeAndSweep(approvals, calls, sweeps);
+    }
+
+    // ─── Approvals ──────────────────────────────────────────────────
+
+    function test_approvalSetsMaxAllowance() external {
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](1);
+        approvals[0] = IntentExecutor.Approval({ token: address(tokenA), spender: address(this) });
+
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        executor.executeAndSweep(approvals, calls, sweeps);
+
+        assertEq(tokenA.allowance(address(executor), address(this)), type(uint256).max);
+    }
+
+    function test_repeatApprovalSavesGas() external {
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](1);
+        approvals[0] = IntentExecutor.Approval({ token: address(tokenA), spender: address(this) });
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        // First call — cold SSTORE
+        uint256 gasBefore1 = gasleft();
+        executor.executeAndSweep(approvals, calls, sweeps);
+        uint256 gasUsed1 = gasBefore1 - gasleft();
+
+        // Second call — already max approved, should be cheaper (SLOAD only)
+        uint256 gasBefore2 = gasleft();
+        executor.executeAndSweep(approvals, calls, sweeps);
+        uint256 gasUsed2 = gasBefore2 - gasleft();
+
+        assertLt(gasUsed2, gasUsed1);
+    }
+
+    // ─── Receive ────────────────────────────────────────────────────
+
+    function test_receiveAcceptsEth() external {
+        vm.deal(address(this), 1 ether);
+        (bool ok,) = address(executor).call{ value: 1 ether }("");
+        assertTrue(ok);
+        assertEq(address(executor).balance, 1 ether);
+    }
+
+    // ─── End-to-end: approve → swap → fee → sweep ──────────────────
+
+    function test_endToEnd_approveSwapFeeSweep() external {
+        uint256 inputAmount = 10 ether;
+        uint256 feeAmount = inputAmount / 100; // 1%
+        uint256 swapOutput = 9 ether;
+        tokenA.mint(address(executor), inputAmount);
+
+        // Phase 1: Approve tokenA to this contract (simulating DEX approval)
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](1);
+        approvals[0] = IntentExecutor.Approval({ token: address(tokenA), spender: address(this) });
+
+        // Phase 2: Two calls — fee transfer + simulated swap (mint output token)
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](2);
+        // Fee transfer
+        calls[0] = IntentExecutor.Call3({
+            target: address(tokenA),
+            allowFailure: false,
+            callData: abi.encodeCall(MockERC20.transfer, (feeCollector, feeAmount))
+        });
+        // Simulated swap: burn input, mint output to executor
+        calls[1] = IntentExecutor.Call3({
+            target: address(tokenB),
+            allowFailure: false,
+            callData: abi.encodeCall(MockERC20.mint, (address(executor), swapOutput))
+        });
+
+        // Phase 3: Sweep output token to recipient
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](1);
+        sweeps[0] = IntentExecutor.SweepTarget({ token: address(tokenB), recipient: recipient });
+
+        executor.executeAndSweep(approvals, calls, sweeps);
+
+        assertEq(tokenA.balanceOf(feeCollector), feeAmount);
+        assertEq(tokenB.balanceOf(recipient), swapOutput);
+        assertEq(tokenB.balanceOf(address(executor)), 0);
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────
+
+    receive() external payable { }
+}

--- a/solidity/test/libs/IntentExecutor.t.sol
+++ b/solidity/test/libs/IntentExecutor.t.sol
@@ -205,7 +205,7 @@ contract IntentExecutorTest is Test {
             target: address(tokenA),
             allowFailure: false,
             callData: abi.encodeCall(MockERC20.transfer, (recipient, 999 ether)) // no balance
-         });
+        });
         IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
 
         vm.expectRevert();
@@ -219,7 +219,7 @@ contract IntentExecutorTest is Test {
             target: address(tokenA),
             allowFailure: true,
             callData: abi.encodeCall(MockERC20.transfer, (recipient, 999 ether)) // no balance
-         });
+        });
         IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
 
         IntentExecutor.Result[] memory results = executor.executeAndSweep(approvals, calls, sweeps);


### PR DESCRIPTION
IntentExecutor is a stateless multicall contract that serves as the execution target for Intent Factory bundle execution, replacing Multicall3.

  Three-phase execution:
  1. **Safe approvals** — `safeApproveWithRetry(type(uint256).max)` for input tokens to DEX contracts
  2. **Call execution** — arbitrary batched calls (swaps, fee transfers)
  3. **Balance sweep** — transfers full remaining `balanceOf(this)` to the recipient

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reorganized repository as a monorepo with separate Solidity and TypeScript packages
  * Added support for multiple public key types (ECDSA, P256, WebAuthn-P256) for account ownership
  * Introduced constrained asset transaction capabilities with allowance and outcome validation
  * Added intent execution functionality for batched transactions with token sweeps
  * Released TypeScript library for account management, transaction building, and signing

* **Documentation**
  * Added comprehensive contributor guidelines and development documentation
  * Updated project README with new monorepo structure overview

* **Tests & CI**
  * Implemented automated test workflows for both Solidity and TypeScript packages
  * Added extensive integration and unit test coverage
<!-- end of auto-generated comment: release notes by coderabbit.ai -->