### PR TITLE
(audit 6.1.2) CatapultarFactory allows _saltPrefix() collisions

### DIFF
--- a/solidity/snapshots/CatapultarFactoryTest.json
+++ b/solidity/snapshots/CatapultarFactoryTest.json
@@ -1,5 +1,5 @@
 {
-  "deploy": "117737",
-  "deployUpgradeable": "143021",
-  "deployWithDigest": "143234"
+  "deploy": "117726",
+  "deployUpgradeable": "143215",
+  "deployWithDigest": "143223"
 }

--- a/solidity/snapshots/CatapultarFactoryTest.json
+++ b/solidity/snapshots/CatapultarFactoryTest.json
@@ -1,5 +1,5 @@
 {
-  "deploy": "117786",
-  "deployUpgradeable": "143266",
-  "deployWithDigest": "143295"
+  "deploy": "117737",
+  "deployUpgradeable": "143021",
+  "deployWithDigest": "143234"
 }

--- a/solidity/snapshots/CatapultarFactoryTronTest.json
+++ b/solidity/snapshots/CatapultarFactoryTronTest.json
@@ -1,5 +1,5 @@
 {
-  "deploy": "117729",
-  "deployUpgradeable": "143245",
-  "deployWithDigest": "143250"
+  "deploy": "117737",
+  "deployUpgradeable": "143021",
+  "deployWithDigest": "143234"
 }

--- a/solidity/src/CatapultarFactory.sol
+++ b/solidity/src/CatapultarFactory.sol
@@ -31,6 +31,7 @@ import { KeyedOwnable } from "./libs/KeyedOwnable.sol";
  * The owner of a deployed proxy may not be the same as the owner it was deployed with.
  */
 contract CatapultarFactory {
+    error TooManyOwners();
     address payable public immutable EXECUTOR;
 
     constructor() {
@@ -47,8 +48,8 @@ contract CatapultarFactory {
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
         bytes32 salt
-    ) external payable ownerInSalt(salt, ktp, owner) returns (address payable proxy) {
-        proxy = payable(LibClone.cloneDeterministic_PUSH0(EXECUTOR, salt));
+    ) external payable returns (address payable proxy) {
+        proxy = payable(LibClone.cloneDeterministic_PUSH0(EXECUTOR, _salt(salt, ktp, owner)));
 
         Catapultar(payable(proxy)).init{ value: msg.value }(ktp, owner);
     }
@@ -60,8 +61,8 @@ contract CatapultarFactory {
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
         bytes32 salt
-    ) external view ownerInSalt(salt, ktp, owner) returns (address proxy) {
-        return LibClone.predictDeterministicAddress_PUSH0(EXECUTOR, salt, address(this));
+    ) external view returns (address proxy) {
+        return LibClone.predictDeterministicAddress_PUSH0(EXECUTOR, _salt(salt, ktp, owner), address(this));
     }
 
     /// @param salt The first 20 bytes of salt has to be the owner or 0.
@@ -71,7 +72,7 @@ contract CatapultarFactory {
         bytes32 salt,
         bytes32 digest,
         bool isSignature
-    ) external payable ownerInSalt(salt, ktp, owner) returns (address payable proxy) {
+    ) external payable returns (address payable proxy) {
         uint256 nonce;
         assembly ("memory-safe") {
             // Catapultar.DigestApproval.Call == 1
@@ -79,7 +80,7 @@ contract CatapultarFactory {
             // isSignature + 1 == 2 if isSignature === true otherwise 1.
             nonce := add(isSignature, 1)
         }
-        bytes32 saltWithDigest = EfficientHashLib.hash(salt, digest, bytes32(nonce));
+        bytes32 saltWithDigest = EfficientHashLib.hash(_salt(salt, ktp, owner), digest, bytes32(nonce));
         proxy = payable(LibClone.cloneDeterministic_PUSH0(EXECUTOR, saltWithDigest));
 
         // forge-lint: disable-next-line(unsafe-typecast)
@@ -97,7 +98,7 @@ contract CatapultarFactory {
         bytes32 salt,
         bytes32 digest,
         bool isSignature
-    ) external view ownerInSalt(salt, ktp, owner) returns (address proxy) {
+    ) external view returns (address proxy) {
         uint256 nonce;
         assembly ("memory-safe") {
             // Catapultar.DigestApproval.Call == 1
@@ -105,7 +106,7 @@ contract CatapultarFactory {
             // isSignature + 1 == 2 if isSignature === true otherwise 1.
             nonce := add(isSignature, 1)
         }
-        bytes32 saltWithDigest = EfficientHashLib.hash(salt, digest, bytes32(nonce));
+        bytes32 saltWithDigest = EfficientHashLib.hash(_salt(salt, ktp, owner), digest, bytes32(nonce));
         return LibClone.predictDeterministicAddress_PUSH0(EXECUTOR, saltWithDigest, address(this));
     }
 
@@ -114,7 +115,7 @@ contract CatapultarFactory {
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
         bytes32 salt
-    ) external payable ownerInSalt(salt, ktp, owner) returns (address payable proxy) {
+    ) external payable returns (address payable proxy) {
         proxy = payable(LibClone.deployDeterministicERC1967(EXECUTOR, salt));
 
         Catapultar(payable(proxy)).init{ value: msg.value }(ktp, owner);
@@ -129,38 +130,39 @@ contract CatapultarFactory {
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
         bytes32 salt
-    ) external view ownerInSalt(salt, ktp, owner) returns (address proxy) {
+    ) external view returns (address proxy) {
         return LibClone.predictDeterministicAddressERC1967(EXECUTOR, salt, address(this));
     }
 
     // --- Helpers --- //
 
     /**
-     * @notice Requires that the salt contains the owner as the first 20 bytes or they are 0.
-     * @dev When deploying proxies, it may not be safe to set the first 20 bytes to 0. If this is desired, the risk is
-     * entirely up to the user.
-     * For a key larger than 20 bytes, the first 20 bytes are taken of keccak256(ktp, keccak256(owner))
+     * @notice Computes a new salt based on the provided creation parameters
      * @param salt A bytes32 value intended to pseudo-randomize the deployed address.
      * @param ktp The keytype for the account
      * @param owner A desired callable parameter for a proxy address
      */
-    modifier ownerInSalt(
-        bytes32 salt,
+    function _salt(
+        bytes32 preSalt,
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner
-    ) {
-        LibClone.checkStartsWith(salt, _saltPrefix(ktp, owner));
-        _;
-    }
+    ) internal pure returns (bytes32 salt) {
+        uint256 numOwners = owner.length;
+        if (numOwners > type(uint8).max) revert TooManyOwners();
+        assembly ("memory-safe") {
+            let m := mload(0x40)
 
-    function _saltPrefix(
-        KeyedOwnable.PublicKeyType ktp,
-        bytes32[] calldata owner
-    ) internal pure returns (address) {
-        if (ktp == KeyedOwnable.PublicKeyType.ECDSAOrSmartContract && owner.length == 1) {
-            return address(uint160(uint256(owner[0])));
-        } else {
-            return address(bytes20(EfficientHashLib.hash(bytes32(uint256(uint8(ktp))), EfficientHashLib.hash(owner))));
+            // In memory, store:
+            // [m .. m+31]:         preSalt
+            // [m+32]:              ktp
+            // [m+33]:              numOwners
+            // [m+34 .. m+33+N*32]: owners
+            mstore(m, preSalt)
+            mstore8(add(m, 32), ktp)
+            mstore8(add(m, 33), numOwners)
+            calldatacopy(add(m, 34), owner.offset, mul(numOwners, 32))
+
+            salt := keccak256(m, add(34, mul(numOwners, 32)))
         }
     }
 }

--- a/solidity/src/CatapultarFactory.sol
+++ b/solidity/src/CatapultarFactory.sol
@@ -43,7 +43,6 @@ contract CatapultarFactory {
         return version;
     }
 
-    /// @param salt The first 20 bytes of salt has to be the owner or 0.
     function deploy(
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
@@ -56,7 +55,6 @@ contract CatapultarFactory {
 
     /// @dev Do not trust that the owner of the returned proxy is equal to the provided owner. Ownership may have been
     /// handed over.
-    /// @param salt The first 20 bytes of salt has to be the owner or 0.
     function predictDeploy(
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
@@ -65,7 +63,6 @@ contract CatapultarFactory {
         return LibClone.predictDeterministicAddress_PUSH0(EXECUTOR, _salt(salt, ktp, owner), address(this));
     }
 
-    /// @param salt The first 20 bytes of salt has to be the owner or 0.
     function deployWithDigest(
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
@@ -91,7 +88,6 @@ contract CatapultarFactory {
 
     /// @dev Do not trust that the owner of the returned proxy is equal to the provided owner. Ownership may have been
     /// handed over.
-    /// @param salt The first 20 bytes of salt has to be the owner or 0.
     function predictDeployWithDigest(
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
@@ -110,13 +106,12 @@ contract CatapultarFactory {
         return LibClone.predictDeterministicAddress_PUSH0(EXECUTOR, saltWithDigest, address(this));
     }
 
-    /// @param salt The first 20 bytes of salt has to be the owner or 0.
     function deployUpgradeable(
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
         bytes32 salt
     ) external payable returns (address payable proxy) {
-        proxy = payable(LibClone.deployDeterministicERC1967(EXECUTOR, salt));
+        proxy = payable(LibClone.deployDeterministicERC1967(EXECUTOR, _salt(salt, ktp, owner)));
 
         Catapultar(payable(proxy)).init{ value: msg.value }(ktp, owner);
     }
@@ -125,13 +120,12 @@ contract CatapultarFactory {
     /// handed over.
     /// Do not trust that the implementation of the returned proxy matches the expected version of Catapultar or
     /// Catapultar in general. The contract implementation is upgradeable.
-    /// @param salt The first 20 bytes of salt has to be the owner or 0.
     function predictDeployUpgradeable(
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
         bytes32 salt
     ) external view returns (address proxy) {
-        return LibClone.predictDeterministicAddressERC1967(EXECUTOR, salt, address(this));
+        return LibClone.predictDeterministicAddressERC1967(EXECUTOR, _salt(salt, ktp, owner), address(this));
     }
 
     // --- Helpers --- //

--- a/solidity/src/CatapultarFactory.tron.sol
+++ b/solidity/src/CatapultarFactory.tron.sol
@@ -43,7 +43,6 @@ contract CatapultarFactoryTron {
         return version;
     }
 
-    /// @param salt The first 20 bytes of salt has to be the owner or 0.
     function deploy(
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
@@ -56,7 +55,6 @@ contract CatapultarFactoryTron {
 
     /// @dev Do not trust that the owner of the returned proxy is equal to the provided owner. Ownership may have been
     /// handed over.
-    /// @param salt The first 20 bytes of salt has to be the owner or 0.
     function predictDeploy(
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
@@ -65,7 +63,6 @@ contract CatapultarFactoryTron {
         return LibCloneTron.predictDeterministicAddress_PUSH0(EXECUTOR, _salt(salt, ktp, owner), address(this));
     }
 
-    /// @param salt The first 20 bytes of salt has to be the owner or 0.
     function deployWithDigest(
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
@@ -91,7 +88,6 @@ contract CatapultarFactoryTron {
 
     /// @dev Do not trust that the owner of the returned proxy is equal to the provided owner. Ownership may have been
     /// handed over.
-    /// @param salt The first 20 bytes of salt has to be the owner or 0.
     function predictDeployWithDigest(
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
@@ -110,13 +106,12 @@ contract CatapultarFactoryTron {
         return LibCloneTron.predictDeterministicAddress_PUSH0(EXECUTOR, saltWithDigest, address(this));
     }
 
-    /// @param salt The first 20 bytes of salt has to be the owner or 0.
     function deployUpgradeable(
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
         bytes32 salt
     ) external payable returns (address payable proxy) {
-        proxy = payable(LibCloneTron.deployDeterministicERC1967(EXECUTOR, salt));
+        proxy = payable(LibCloneTron.deployDeterministicERC1967(EXECUTOR, _salt(salt, ktp, owner)));
 
         Catapultar(payable(proxy)).init{ value: msg.value }(ktp, owner);
     }
@@ -125,22 +120,18 @@ contract CatapultarFactoryTron {
     /// handed over.
     /// Do not trust that the implementation of the returned proxy matches the expected version of Catapultar or
     /// Catapultar in general. The contract implementation is upgradeable.
-    /// @param salt The first 20 bytes of salt has to be the owner or 0.
     function predictDeployUpgradeable(
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
         bytes32 salt
     ) external view returns (address proxy) {
-        return LibCloneTron.predictDeterministicAddressERC1967(EXECUTOR, salt, address(this));
+        return LibCloneTron.predictDeterministicAddressERC1967(EXECUTOR, _salt(salt, ktp, owner), address(this));
     }
 
     // --- Helpers --- //
 
     /**
-     * @notice Computes a new salt based on the provided creation parameters.
-     * @dev When deploying proxies, it may not be safe to set the first 20 bytes to 0. If this is desired, the risk is
-     * entirely up to the user.
-     * For a key larger than 20 bytes, the first 20 bytes are taken of keccak256(ktp, keccak256(owner))
+     * @notice Computes a new salt based on the provided creation parameters
      * @param preSalt A bytes32 value intended to pseudo-randomize the deployed address.
      * @param ktp The keytype for the account
      * @param owner A desired callable parameter for a proxy address

--- a/solidity/src/CatapultarFactory.tron.sol
+++ b/solidity/src/CatapultarFactory.tron.sol
@@ -31,6 +31,7 @@ import { KeyedOwnable } from "./libs/KeyedOwnable.sol";
  * The owner of a deployed proxy may not be the same as the owner it was deployed with.
  */
 contract CatapultarFactoryTron {
+    error TooManyOwners();
     address payable public immutable EXECUTOR;
 
     constructor() {
@@ -47,8 +48,8 @@ contract CatapultarFactoryTron {
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
         bytes32 salt
-    ) external payable ownerInSalt(salt, ktp, owner) returns (address payable proxy) {
-        proxy = payable(LibCloneTron.cloneDeterministic_PUSH0(EXECUTOR, salt));
+    ) external payable returns (address payable proxy) {
+        proxy = payable(LibCloneTron.cloneDeterministic_PUSH0(EXECUTOR, _salt(salt, ktp, owner)));
 
         Catapultar(payable(proxy)).init{ value: msg.value }(ktp, owner);
     }
@@ -60,8 +61,8 @@ contract CatapultarFactoryTron {
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
         bytes32 salt
-    ) external view ownerInSalt(salt, ktp, owner) returns (address proxy) {
-        return LibCloneTron.predictDeterministicAddress_PUSH0(EXECUTOR, salt, address(this));
+    ) external view returns (address proxy) {
+        return LibCloneTron.predictDeterministicAddress_PUSH0(EXECUTOR, _salt(salt, ktp, owner), address(this));
     }
 
     /// @param salt The first 20 bytes of salt has to be the owner or 0.
@@ -71,7 +72,7 @@ contract CatapultarFactoryTron {
         bytes32 salt,
         bytes32 digest,
         bool isSignature
-    ) external payable ownerInSalt(salt, ktp, owner) returns (address payable proxy) {
+    ) external payable returns (address payable proxy) {
         uint256 nonce;
         assembly ("memory-safe") {
             // Catapultar.DigestApproval.Call == 1
@@ -79,7 +80,7 @@ contract CatapultarFactoryTron {
             // isSignature + 1 == 2 if isSignature === true otherwise 1.
             nonce := add(isSignature, 1)
         }
-        bytes32 saltWithDigest = EfficientHashLib.hash(salt, digest, bytes32(nonce));
+        bytes32 saltWithDigest = EfficientHashLib.hash(_salt(salt, ktp, owner), digest, bytes32(nonce));
         proxy = payable(LibCloneTron.cloneDeterministic_PUSH0(EXECUTOR, saltWithDigest));
 
         // forge-lint: disable-next-line(unsafe-typecast)
@@ -97,7 +98,7 @@ contract CatapultarFactoryTron {
         bytes32 salt,
         bytes32 digest,
         bool isSignature
-    ) external view ownerInSalt(salt, ktp, owner) returns (address proxy) {
+    ) external view returns (address proxy) {
         uint256 nonce;
         assembly ("memory-safe") {
             // Catapultar.DigestApproval.Call == 1
@@ -105,7 +106,7 @@ contract CatapultarFactoryTron {
             // isSignature + 1 == 2 if isSignature === true otherwise 1.
             nonce := add(isSignature, 1)
         }
-        bytes32 saltWithDigest = EfficientHashLib.hash(salt, digest, bytes32(nonce));
+        bytes32 saltWithDigest = EfficientHashLib.hash(_salt(salt, ktp, owner), digest, bytes32(nonce));
         return LibCloneTron.predictDeterministicAddress_PUSH0(EXECUTOR, saltWithDigest, address(this));
     }
 
@@ -114,7 +115,7 @@ contract CatapultarFactoryTron {
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
         bytes32 salt
-    ) external payable ownerInSalt(salt, ktp, owner) returns (address payable proxy) {
+    ) external payable returns (address payable proxy) {
         proxy = payable(LibCloneTron.deployDeterministicERC1967(EXECUTOR, salt));
 
         Catapultar(payable(proxy)).init{ value: msg.value }(ktp, owner);
@@ -129,38 +130,42 @@ contract CatapultarFactoryTron {
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner,
         bytes32 salt
-    ) external view ownerInSalt(salt, ktp, owner) returns (address proxy) {
+    ) external view returns (address proxy) {
         return LibCloneTron.predictDeterministicAddressERC1967(EXECUTOR, salt, address(this));
     }
 
     // --- Helpers --- //
 
     /**
-     * @notice Requires that the salt contains the owner as the first 20 bytes or they are 0.
+     * @notice Computes a new salt based on the provided creation parameters.
      * @dev When deploying proxies, it may not be safe to set the first 20 bytes to 0. If this is desired, the risk is
      * entirely up to the user.
      * For a key larger than 20 bytes, the first 20 bytes are taken of keccak256(ktp, keccak256(owner))
-     * @param salt A bytes32 value intended to pseudo-randomize the deployed address.
+     * @param preSalt A bytes32 value intended to pseudo-randomize the deployed address.
      * @param ktp The keytype for the account
      * @param owner A desired callable parameter for a proxy address
      */
-    modifier ownerInSalt(
-        bytes32 salt,
+    function _salt(
+        bytes32 preSalt,
         KeyedOwnable.PublicKeyType ktp,
         bytes32[] calldata owner
-    ) {
-        LibCloneTron.checkStartsWith(salt, _saltPrefix(ktp, owner));
-        _;
-    }
+    ) internal pure returns (bytes32 salt) {
+        uint256 numOwners = owner.length;
+        if (numOwners > type(uint8).max) revert TooManyOwners();
+        assembly ("memory-safe") {
+            let m := mload(0x40)
 
-    function _saltPrefix(
-        KeyedOwnable.PublicKeyType ktp,
-        bytes32[] calldata owner
-    ) internal pure returns (address) {
-        if (ktp == KeyedOwnable.PublicKeyType.ECDSAOrSmartContract && owner.length == 1) {
-            return address(uint160(uint256(owner[0])));
-        } else {
-            return address(bytes20(EfficientHashLib.hash(bytes32(uint256(uint8(ktp))), EfficientHashLib.hash(owner))));
+            // In memory, store:
+            // [m .. m+31]:         preSalt
+            // [m+32]:              ktp
+            // [m+33]:              numOwners
+            // [m+34 .. m+33+N*32]: owners
+            mstore(m, preSalt)
+            mstore8(add(m, 32), ktp)
+            mstore8(add(m, 33), numOwners)
+            calldatacopy(add(m, 34), owner.offset, mul(numOwners, 32))
+
+            salt := keccak256(m, add(34, mul(numOwners, 32)))
         }
     }
 }

--- a/solidity/test/CatapultarFactory.t.sol
+++ b/solidity/test/CatapultarFactory.t.sol
@@ -126,6 +126,12 @@ contract CatapultarFactoryTest is Test {
         assertEq(predictedDeployedTo, deployedTo);
     }
 
+    function testRevert_tooManyOwners() external {
+        bytes32[] memory keys = new bytes32[](256);
+        vm.expectRevert(abi.encodeWithSignature("TooManyOwners()"));
+        factory.predictDeploy(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, bytes32(0));
+    }
+
     // Verifies that _salt encodes preSalt || ktp || numOwners || owners as documented.
     function test_saltEncoding() external view {
         bytes32 preSalt = bytes32(uint256(0xdead));

--- a/solidity/test/CatapultarFactory.t.sol
+++ b/solidity/test/CatapultarFactory.t.sol
@@ -5,6 +5,8 @@ pragma solidity ^0.8.30;
 
 import { Test } from "forge-std/src/Test.sol";
 
+import { LibClone } from "solady/src/utils/LibClone.sol";
+
 import { CatapultarFactory } from "../src/CatapultarFactory.sol";
 import { KeyedOwnable } from "../src/libs/KeyedOwnable.sol";
 
@@ -124,89 +126,19 @@ contract CatapultarFactoryTest is Test {
         assertEq(predictedDeployedTo, deployedTo);
     }
 
-    // --- Check salt contains owner --- //
+    // Verifies that _salt encodes preSalt || ktp || numOwners || owners as documented.
+    function test_saltEncoding() external view {
+        bytes32 preSalt = bytes32(uint256(0xdead));
+        KeyedOwnable.PublicKeyType ktp = KeyedOwnable.PublicKeyType.P256;
 
-    function testRevert_deploy_salt_does_not_contain_owner(
-        address owner,
-        bytes32 salt
-    ) external {
-        vm.assume(owner != address(0));
-        if (bytes20(salt) != bytes20(0) && address(uint160(bytes20(salt))) != owner) {
-            vm.expectRevert(abi.encodeWithSignature("SaltDoesNotStartWith()"));
-        }
-        bytes32[] memory keys = new bytes32[](1);
-        keys[0] = bytes32(uint256(uint160(owner)));
+        bytes32[] memory keys = new bytes32[](2);
+        keys[0] = bytes32(uint256(1));
+        keys[1] = bytes32(uint256(2));
 
-        factory.deploy(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, salt);
+        bytes32 expectedSalt = keccak256(abi.encodePacked(preSalt, uint8(ktp), uint8(keys.length), keys[0], keys[1]));
+        address expected = LibClone.predictDeterministicAddress_PUSH0(factory.EXECUTOR(), expectedSalt, address(factory));
+
+        assertEq(factory.predictDeploy(ktp, keys, preSalt), expected);
     }
 
-    function testRevert_deployWithDigest_salt_does_not_contain_owner(
-        address owner,
-        bytes32 salt
-    ) external {
-        vm.assume(owner != address(0));
-        if (bytes20(salt) != bytes20(0) && address(uint160(bytes20(salt))) != owner) {
-            vm.expectRevert(abi.encodeWithSignature("SaltDoesNotStartWith()"));
-        }
-        bytes32[] memory keys = new bytes32[](1);
-        keys[0] = bytes32(uint256(uint160(owner)));
-
-        factory.deployWithDigest(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, salt, bytes32(0), false);
-    }
-
-    function testRevert_deployUpgradeable_salt_does_not_contain_owner(
-        address owner,
-        bytes32 salt
-    ) external {
-        vm.assume(owner != address(0));
-        if (bytes20(salt) != bytes20(0) && address(uint160(bytes20(salt))) != owner) {
-            vm.expectRevert(abi.encodeWithSignature("SaltDoesNotStartWith()"));
-        }
-        bytes32[] memory keys = new bytes32[](1);
-        keys[0] = bytes32(uint256(uint160(owner)));
-
-        factory.deployUpgradeable(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, salt);
-    }
-
-    function testRevert_predictDeploy_salt_does_not_contain_owner(
-        address owner,
-        bytes32 salt
-    ) external {
-        vm.assume(owner != address(0));
-        if (bytes20(salt) != bytes20(0) && address(uint160(bytes20(salt))) != owner) {
-            vm.expectRevert(abi.encodeWithSignature("SaltDoesNotStartWith()"));
-        }
-        bytes32[] memory keys = new bytes32[](1);
-        keys[0] = bytes32(uint256(uint160(owner)));
-
-        factory.predictDeploy(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, salt);
-    }
-
-    function testRevert_predictDeployWithDigest_salt_does_not_contain_owner(
-        address owner,
-        bytes32 salt
-    ) external {
-        vm.assume(owner != address(0));
-        if (bytes20(salt) != bytes20(0) && address(uint160(bytes20(salt))) != owner) {
-            vm.expectRevert(abi.encodeWithSignature("SaltDoesNotStartWith()"));
-        }
-        bytes32[] memory keys = new bytes32[](1);
-        keys[0] = bytes32(uint256(uint160(owner)));
-
-        factory.predictDeployWithDigest(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, salt, bytes32(0), false);
-    }
-
-    function testRevert_predictDeployUpgradeable_salt_does_not_contain_owner(
-        address owner,
-        bytes32 salt
-    ) external {
-        vm.assume(owner != address(0));
-        if (bytes20(salt) != bytes20(0) && address(uint160(bytes20(salt))) != owner) {
-            vm.expectRevert(abi.encodeWithSignature("SaltDoesNotStartWith()"));
-        }
-        bytes32[] memory keys = new bytes32[](1);
-        keys[0] = bytes32(uint256(uint160(owner)));
-
-        factory.predictDeployUpgradeable(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, salt);
-    }
 }

--- a/solidity/test/Tron/CatapultarFactory.tron.t.sol
+++ b/solidity/test/Tron/CatapultarFactory.tron.t.sol
@@ -5,6 +5,8 @@ pragma solidity ^0.8.30;
 
 import { Test } from "forge-std/src/Test.sol";
 
+import { LibCloneTron } from "../../src/libs/LibClone.tron.sol";
+
 import { CatapultarFactoryTron } from "../../src/CatapultarFactory.tron.sol";
 import { KeyedOwnable } from "../../src/libs/KeyedOwnable.sol";
 
@@ -167,89 +169,20 @@ contract CatapultarFactoryTronTest is Test {
         assertNotEq(minimal, upgradeable);
     }
 
-    // --- Check salt contains owner --- //
+    // Verifies that _salt encodes preSalt || ktp || numOwners || owners as documented.
+    function test_saltEncoding() external view {
+        bytes32 preSalt = bytes32(uint256(0xdead));
+        KeyedOwnable.PublicKeyType ktp = KeyedOwnable.PublicKeyType.P256;
 
-    function testRevert_deploy_salt_does_not_contain_owner(
-        address owner,
-        bytes32 salt
-    ) external {
-        vm.assume(owner != address(0));
-        if (bytes20(salt) != bytes20(0) && address(uint160(bytes20(salt))) != owner) {
-            vm.expectRevert(abi.encodeWithSignature("SaltDoesNotStartWith()"));
-        }
-        bytes32[] memory keys = new bytes32[](1);
-        keys[0] = bytes32(uint256(uint160(owner)));
+        bytes32[] memory keys = new bytes32[](2);
+        keys[0] = bytes32(uint256(1));
+        keys[1] = bytes32(uint256(2));
 
-        factory.deploy(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, salt);
+        bytes32 expectedSalt = keccak256(abi.encodePacked(preSalt, uint8(ktp), uint8(keys.length), keys[0], keys[1]));
+        address expected =
+            LibCloneTron.predictDeterministicAddress_PUSH0(factory.EXECUTOR(), expectedSalt, address(factory));
+
+        assertEq(factory.predictDeploy(ktp, keys, preSalt), expected);
     }
 
-    function testRevert_deployWithDigest_salt_does_not_contain_owner(
-        address owner,
-        bytes32 salt
-    ) external {
-        vm.assume(owner != address(0));
-        if (bytes20(salt) != bytes20(0) && address(uint160(bytes20(salt))) != owner) {
-            vm.expectRevert(abi.encodeWithSignature("SaltDoesNotStartWith()"));
-        }
-        bytes32[] memory keys = new bytes32[](1);
-        keys[0] = bytes32(uint256(uint160(owner)));
-
-        factory.deployWithDigest(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, salt, bytes32(0), false);
-    }
-
-    function testRevert_deployUpgradeable_salt_does_not_contain_owner(
-        address owner,
-        bytes32 salt
-    ) external {
-        vm.assume(owner != address(0));
-        if (bytes20(salt) != bytes20(0) && address(uint160(bytes20(salt))) != owner) {
-            vm.expectRevert(abi.encodeWithSignature("SaltDoesNotStartWith()"));
-        }
-        bytes32[] memory keys = new bytes32[](1);
-        keys[0] = bytes32(uint256(uint160(owner)));
-
-        factory.deployUpgradeable(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, salt);
-    }
-
-    function testRevert_predictDeploy_salt_does_not_contain_owner(
-        address owner,
-        bytes32 salt
-    ) external {
-        vm.assume(owner != address(0));
-        if (bytes20(salt) != bytes20(0) && address(uint160(bytes20(salt))) != owner) {
-            vm.expectRevert(abi.encodeWithSignature("SaltDoesNotStartWith()"));
-        }
-        bytes32[] memory keys = new bytes32[](1);
-        keys[0] = bytes32(uint256(uint160(owner)));
-
-        factory.predictDeploy(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, salt);
-    }
-
-    function testRevert_predictDeployWithDigest_salt_does_not_contain_owner(
-        address owner,
-        bytes32 salt
-    ) external {
-        vm.assume(owner != address(0));
-        if (bytes20(salt) != bytes20(0) && address(uint160(bytes20(salt))) != owner) {
-            vm.expectRevert(abi.encodeWithSignature("SaltDoesNotStartWith()"));
-        }
-        bytes32[] memory keys = new bytes32[](1);
-        keys[0] = bytes32(uint256(uint160(owner)));
-
-        factory.predictDeployWithDigest(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, salt, bytes32(0), false);
-    }
-
-    function testRevert_predictDeployUpgradeable_salt_does_not_contain_owner(
-        address owner,
-        bytes32 salt
-    ) external {
-        vm.assume(owner != address(0));
-        if (bytes20(salt) != bytes20(0) && address(uint160(bytes20(salt))) != owner) {
-            vm.expectRevert(abi.encodeWithSignature("SaltDoesNotStartWith()"));
-        }
-        bytes32[] memory keys = new bytes32[](1);
-        keys[0] = bytes32(uint256(uint160(owner)));
-
-        factory.predictDeployUpgradeable(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, salt);
-    }
 }

--- a/solidity/test/Tron/CatapultarFactory.tron.t.sol
+++ b/solidity/test/Tron/CatapultarFactory.tron.t.sol
@@ -169,6 +169,12 @@ contract CatapultarFactoryTronTest is Test {
         assertNotEq(minimal, upgradeable);
     }
 
+    function testRevert_tooManyOwners() external {
+        bytes32[] memory keys = new bytes32[](256);
+        vm.expectRevert(abi.encodeWithSignature("TooManyOwners()"));
+        factory.predictDeploy(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, keys, bytes32(0));
+    }
+
     // Verifies that _salt encodes preSalt || ktp || numOwners || owners as documented.
     function test_saltEncoding() external view {
         bytes32 preSalt = bytes32(uint256(0xdead));


### PR DESCRIPTION
Refine factory salt computation

Replaces the `ownerInSalt` modifier and `_saltPrefix` branching logic in both `CatapultarFactory` and `CatapultarFactoryTron` with a unified `_salt(preSalt, ktp, owner)` function.

Why: The old `_saltPrefix` had a collision vulnerability (audit 6.1.2) — an attacker could register an
`ECDSAOrSmartContract` owner whose raw value matched the hash-derived prefix of a victim's P256/WebAuthn key, front-running their deployment and bricking the address.

What changed:
- `_salt` now hashes all inputs together: `keccak256(preSalt ‖ ktp ‖ numOwners ‖ owners...)`, making cross-key-type collisions computationally infeasible
- `preSalt` is included so different user-provided salts always yield different addresses
-  `TooManyOwners` guard added (>255 owners reverts)
- Stale `SaltDoesNotStartWith` revert tests removed; new tests added covering salt encoding correctness and the TooManyOwners path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced account deployment with multiple key types (ECDSA, P256, WebAuthn P256).
  * Added execution validator (`CATValidator`) for constrained asset transaction approval.
  * Introduced multi-chain account deployment support and Tron network compatibility.
  * New TypeScript SDK for simplified account interactions.

* **Documentation**
  * Comprehensive smart account architecture documentation.

* **Tests**
  * Expanded test coverage across both packages with gas snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->