### PR TITLE
(audit 6.3.1) `_validateSignature()` does not handle short signatures

### DIFF
--- a/solidity/src/libs/KeyedOwnable.sol
+++ b/solidity/src/libs/KeyedOwnable.sol
@@ -265,7 +265,7 @@ contract KeyedOwnable {
                 // extracts the rightmost byte of the 32-byte word, which is exactly the byte at
                 // (signature.offset + n - 1) — i.e., the true last byte of the signature.
                 // The gt(n, 0) guard ensures digestPrehash is always 0 when n = 0.
-                digestPrehash := and(not(iszero(and(calldataload(sub(add(signature.offset, n), 32)), 0xff))), gt(n, 0))
+                digestPrehash := and(iszero(iszero(and(calldataload(sub(add(signature.offset, n), 32)), 0xff))), gt(n, 0))
             }
             if (digestPrehash) {
                 digest = EfficientHashLib.sha2(digest); // `sha256(abi.encode(digest))`.

--- a/solidity/src/libs/KeyedOwnable.sol
+++ b/solidity/src/libs/KeyedOwnable.sol
@@ -235,6 +235,8 @@ contract KeyedOwnable {
      * P256 signatures needs to append 2 bytes to their 64 bytes to get the signature to size 66. The last byte is a
      * flag for rehashing the digest with SHA256.
      * @param signature `abi.encodePacked(bytes(signature), bool(prehash))`.
+     *   - length 0: no prehash byte; empty signature passed to key-type dispatch.
+     *   - length 1: the single byte is the prehash indicator; empty signature passed downstream.
      */
     function _validateSignature(
         bytes32 digest,
@@ -246,13 +248,26 @@ contract KeyedOwnable {
             return SignatureCheckerLib.isValidSignatureNowCalldata(account, digest, signature);
         }
 
-        unchecked {
-            uint256 n = signature.length;
-            // Remove the last byte from the signature
-            signature = LibBytes.truncatedCalldata(signature, n - 1);
-            // Do the prehash if last byte is non-zero. Select the last word of the signature, then select the last byte
-            // of the word.
-            if ((uint256(LibBytes.loadCalldata(signature, n - 32)) & 0xff) != 0) {
+        // We need to load the signature and identify whether we need to do a sha prehash.
+        // If a signature of length 0 is provided, we will process signature as is.
+        // If a signature of length > 0 is provided, the last byte will be a signal byte for whether to sha256 hash the digest before signature validation.
+        {
+            bool digestPrehash;
+            assembly ("memory-safe") {
+                let n := signature.length
+
+                // Subtract 1 from signature length if n > 0
+                signature.length := sub(n, gt(n, 0))
+
+                // Select the last byte of the signature, then check if it is not 0.
+                // For n >= 32 this reads the last 32 bytes of the signature (in-bounds).
+                // For 1 <= n < 32 the calldataload starts before signature.offset, but & 0xff
+                // extracts the rightmost byte of the 32-byte word, which is exactly the byte at
+                // (signature.offset + n - 1) — i.e., the true last byte of the signature.
+                // The gt(n, 0) guard ensures digestPrehash is always 0 when n = 0.
+                digestPrehash := and(not(iszero(and(calldataload(sub(add(signature.offset, n), 32)), 0xff))), gt(n, 0))
+            }
+            if (digestPrehash) {
                 digest = EfficientHashLib.sha2(digest); // `sha256(abi.encode(digest))`.
             }
         }

--- a/solidity/test/libs/KeyedOwnable.t.sol
+++ b/solidity/test/libs/KeyedOwnable.t.sol
@@ -6,6 +6,7 @@ import { Test } from "forge-std/src/Test.sol";
 import { KeyedOwnable } from "../../src/libs/KeyedOwnable.sol";
 
 import { MockKeyedOwnable } from "../mocks/MockKeyedOwnable.sol";
+import { MockERC1271 } from "../mocks/MockERC1271.sol";
 
 import { Base64 } from "solady/src/utils/Base64.sol";
 import { P256 } from "solady/src/utils/P256.sol";
@@ -270,6 +271,60 @@ contract KeyedOwnableTest is P256VerifierEtcher {
         owner[1] = keccak256(bytes("y"));
         vm.expectRevert(KeyedOwnable.InvalidKey.selector);
         ownable.transferOwnership(KeyedOwnable.PublicKeyType.WebAuthnP256, owner);
+    }
+
+    function test_validateSignature_shortSignature() external view {
+        // Audit finding 6.3.1: lengths 0 and 1 are supported inputs (for smart-contract
+        // owners using approvedDigest). Lengths 2–31 are handled safely (no underflow);
+        // the truncated signature is too short for any key-type dispatch and returns false.
+
+        bytes32 digest = keccak256("digest");
+
+        // Zero-length: no prehash byte, empty signature falls through to key-type dispatch
+        assertFalse(ownable.validateSignature(digest, new bytes(0)));
+        // 1-byte, prehash=0: prehash indicator is 0x00, empty signature passed downstream
+        assertFalse(ownable.validateSignature(digest, hex"00"));
+        // 1-byte, prehash=1: digest is sha256-hashed, then empty signature passed downstream
+        assertFalse(ownable.validateSignature(digest, hex"01"));
+        // 2-byte: truncated to 1 byte, too short for any key-type dispatch
+        assertFalse(ownable.validateSignature(digest, new bytes(2)));
+        // 31-byte: truncated to 30 bytes, too short for any key-type dispatch
+        assertFalse(ownable.validateSignature(digest, new bytes(31)));
+    }
+
+    function test_validateSignature_shortSignature_smartContractOwner() external {
+        // Verify that short signatures are forwarded byte-for-byte to the ERC-1271 owner after
+        // the prehash indicator byte is stripped. The mock validates both the forwarded digest
+        // and the forwarded signature bytes.
+
+        bytes32 digest = keccak256("digest");
+        bytes32[] memory ownerSlot = new bytes32[](1);
+
+        MockERC1271 mock = new MockERC1271(digest, hex"ffa345");
+        ownerSlot[0] = bytes32(uint256(uint160(address(mock))));
+        ownable.setOwnership(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, ownerSlot);
+
+        // Case 1: accepted = (digest, 0xffa345), prehash=0x00 → digest unchanged, 0xffa345 forwarded.
+        assertTrue(ownable.validateSignature(digest, abi.encodePacked(hex"ffa345", bytes1(0x00))));
+        assertFalse(ownable.validateSignature(digest, abi.encodePacked(hex"01",    bytes1(0x00))));
+
+        // Case 2: accepted = (digest, 0x01), prehash=0x00 → digest unchanged, 0x01 forwarded.
+        mock.setAccepted(digest, hex"01");
+        assertTrue(ownable.validateSignature(digest, abi.encodePacked(hex"01", bytes1(0x00))));
+        assertFalse(ownable.validateSignature(digest, abi.encodePacked(hex"ffa345", bytes1(0x00))));
+
+        // Case 3: accepted = (digest, 0x) — length-0 input, no prehash byte stripped, digest unchanged.
+        mock.setAccepted(digest, hex"");
+        assertTrue(ownable.validateSignature(digest, new bytes(0)));
+        assertFalse(ownable.validateSignature(digest, abi.encodePacked(hex"ffa345", bytes1(0x00))));
+
+        // Case 4: prehash=0x01 → digest is sha256(digest) before forwarding to ERC-1271.
+        // The mock must expect the sha256-hashed digest; the original digest is rejected.
+        bytes32 sha256Digest = sha256(abi.encodePacked(digest));
+        mock.setAccepted(sha256Digest, hex"ffa345");
+        assertTrue(ownable.validateSignature(digest,  abi.encodePacked(hex"ffa345", bytes1(0x01))));
+        // prehash=0x00 forwards the original digest unchanged — mock now expects sha256Digest, so this fails.
+        assertFalse(ownable.validateSignature(digest, abi.encodePacked(hex"ffa345", bytes1(0x00))));
     }
 
     function test_validateSignature_ECDSA() external view {

--- a/solidity/test/mocks/MockERC1271.sol
+++ b/solidity/test/mocks/MockERC1271.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/// @dev WARNING! This mock is strictly intended for testing purposes only.
+/// Do NOT copy anything here into production code unless you really know what you are doing.
+///
+/// A configurable ERC-1271 mock. Returns the magic value if and only if both:
+///   - the provided signature bytes exactly match `acceptedSignature`, and
+///   - the provided hash exactly matches `acceptedDigest`.
+contract MockERC1271 {
+    bytes4 internal constant _ERC1271_MAGIC_VALUE = 0x1626ba7e;
+
+    bytes32 public acceptedDigest;
+    bytes public acceptedSignature;
+
+    constructor(bytes32 digest, bytes memory signature) {
+        acceptedDigest = digest;
+        acceptedSignature = signature;
+    }
+
+    function setAccepted(bytes32 digest, bytes calldata signature) external {
+        acceptedDigest = digest;
+        acceptedSignature = signature;
+    }
+
+    function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4) {
+        if (hash == acceptedDigest && keccak256(signature) == keccak256(acceptedSignature)) {
+            return _ERC1271_MAGIC_VALUE;
+        }
+        return 0xffffffff;
+    }
+}


### PR DESCRIPTION
Previously the validation library could not handle signature less than 32 bytes long. This is in particularly an issue for smart contract based owners (like Catapultar itself) which might have pre-approved set signatures which requires `signature.length` to be 0 to trigger.

This PR fixes this by rewriting the code in Assembly.