### PR TITLE
(audit 6.1.1) Assert token difference using the validator contract

### DIFF
--- a/solidity/script/deploy.s.sol
+++ b/solidity/script/deploy.s.sol
@@ -40,7 +40,8 @@ contract deploy is multichain {
     }
 
     function deployCATValidator() internal returns (CATValidator validator) {
-        address expectedAddress = getExpectedCreate2Address(bytes32(0), type(CATValidator).creationCode, hex"");
+        address payable expectedAddress =
+            payable(getExpectedCreate2Address(bytes32(0), type(CATValidator).creationCode, hex""));
         if (expectedAddress.code.length == 0) {
             validator = new CATValidator{ salt: bytes32(0) }();
             if (expectedAddress != address(validator)) revert NotExpectedAddress(expectedAddress, address(validator));

--- a/solidity/src/CATValidator.sol
+++ b/solidity/src/CATValidator.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.30;
 
-import { DynamicArrayLib } from "solady/src/utils/DynamicArrayLib.sol";
 import { EIP712 } from "solady/src/utils/EIP712.sol";
 import { ReentrancyGuard } from "solady/src/utils/ReentrancyGuard.sol";
 import { SafeTransferLib } from "solady/src/utils/SafeTransferLib.sol";
@@ -20,10 +19,12 @@ import { AllowanceSpend, LibExecutionConstraint, Outcome } from "./libs/LibExecu
  * transaction of setSignature and approve, allows the configured executor to find calldata to complete the provided
  * description: allowances for outcomes.
  *
- * This contract should never hold assets:
- * - Allowances are collected from the signer and delivered to an executor specified destination.
- * - Outcomes are expected to be delivered directly to the destination specified in the outcome. Initial balances are
- * recorded before allowance transfers and after the external call.
+ * This contract transiently holds outcome assets during settlement:
+ * - Allowances are collected from the signer and delivered to the executor.
+ * - The executor must deliver outcome tokens to this contract during execution.
+ * - After execution, this contract verifies its own token balance meets each outcome amount,
+ *   then forwards the full balance to each outcome's destination.
+ * - Fee on transfer tokens will arrive with the amount minus the fee.
  *
  * This contract uses a call proxy for arbitrary call execution. This makes it safe to set approvals to the contract.
  * This contract does not have a fixed callback function. The call proxy address is ::CALL_PROXY().
@@ -32,7 +33,6 @@ import { AllowanceSpend, LibExecutionConstraint, Outcome } from "./libs/LibExecu
  * long lived approvals like DCAs.
  */
 contract CATValidator is EIP712, ReentrancyGuard {
-    using DynamicArrayLib for uint256[];
     error InvalidTokenAmount(uint256 expected, uint256 received);
     error AllocationTooSmall(uint256 allocated, uint256 spend);
     error NonceAlreadySpent();
@@ -59,10 +59,7 @@ contract CATValidator is EIP712, ReentrancyGuard {
     /**
      * @notice Execute a transaction for an account given a signed execution constraint.
      * @dev This function can only be called by the designated executor. The caller check is made by embedding
-     * msg.sender as the executor in the typehash. This contract does not support _any_ executor and one has to be
-     * provided.
-     * If a destination is address(0), it specifies the signer. If a spend is 0 the current balance of the signer will
-     * be used.
+     * msg.sender as the executor in the typehash. This contract does not support _any_ executor and one has to be provided. If a destination is address(0), it specifies the signer. If a spend is 0 the current balance of the signer will be used.
      */
     function entry(
         address execTarget,
@@ -77,13 +74,11 @@ contract CATValidator is EIP712, ReentrancyGuard {
 
         _validateApproval(account, nonce, allowances, outcomes, signature);
 
-        uint256[] memory recordedBalances = _recordBalances(account, outcomes);
-
         _handleAllowances(execTarget, account, allowances);
 
         if (execPayload.length != 0) _call(execTarget, execPayload);
 
-        _compareOutcomes(account, outcomes, recordedBalances);
+        _validatePayment(account, outcomes);
     }
 
     /**
@@ -122,54 +117,34 @@ contract CATValidator is EIP712, ReentrancyGuard {
     }
 
     /**
-     * @notice Wraps balanceOf call for ERC20 tokens and natives.
-     * @param account Fallback address for to read if outcome.destination is 0.
-     * @param outcome Description of the balance read: target and token. 0 token is native.
+     * @notice Returns the balance of `token` held by `target`.
+     * @param token ERC20 token address. address(0) returns the native ETH balance of `target`.
+     * @param target Account to query.
      */
     function _balanceOf(
-        address account,
-        Outcome calldata outcome
+        address token,
+        address target
     ) internal view returns (uint256 bal) {
-        address destination = outcome.destination == address(0) ? account : outcome.destination;
-        bal = outcome.token == address(0) ? destination.balance : SafeTransferLib.balanceOf(outcome.token, destination);
+        bal = token == address(0) ? target.balance : SafeTransferLib.balanceOf(token, target);
     }
 
     /**
-     * @notice Record balances.
-     * @param account Fallback address if outcomes[].destination is 0.
-     * @param outcomes Description of balances to read: target and token.
-     * @return balances List of current balances of outcomes.
+     * @notice Verify this contract holds enough of each outcome token, then forward to destinations.
+     * @dev The executor is expected to have transferred outcome tokens to address(this) during execution.
+     *      The full held balance is forwarded, so any surplus beyond outcome.amount also goes to the destination.
+     * @param signer Token recipient if outcome.destination is 0.
+     * @param outcomes Tokens and minimum amounts that must be present at address(this).
      */
-    function _recordBalances(
-        address account,
+    function _validatePayment(
+        address signer,
         Outcome[] calldata outcomes
-    ) internal view returns (uint256[] memory balances) {
-        balances = DynamicArrayLib.malloc(outcomes.length);
+    ) internal {
         for (uint256 i; i < outcomes.length; ++i) {
             Outcome calldata outcome = outcomes[i];
-            balances.set(i, _balanceOf(account, outcome));
-        }
-    }
+            uint256 recordedPayment = _balanceOf(outcome.token, address(this));
+            if (recordedPayment < outcome.amount) revert InvalidTokenAmount(outcome.amount, recordedPayment);
 
-    /**
-     * @notice Compare current balances to recorded balances.
-     * @param account Fallback address if outcomes[].destination is 0.
-     * @param outcomes Description of balances to compare: target, token, and difference.
-     * @param recordedBalances List of previously recorded balances.
-     */
-    function _compareOutcomes(
-        address account,
-        Outcome[] calldata outcomes,
-        uint256[] memory recordedBalances
-    ) internal view {
-        for (uint256 i; i < outcomes.length; ++i) {
-            Outcome calldata outcome = outcomes[i];
-            uint256 newBalance = _balanceOf(account, outcome);
-
-            unchecked {
-                uint256 diff = newBalance > recordedBalances[i] ? newBalance - recordedBalances[i] : 0;
-                if (diff < outcome.amount) revert InvalidTokenAmount(outcome.amount, diff);
-            }
+            SafeTransferLib.safeTransfer(outcome.token, outcome.destination == address(0) ? signer : outcome.destination, recordedPayment);
         }
     }
 

--- a/solidity/src/CATValidator.sol
+++ b/solidity/src/CATValidator.sol
@@ -129,6 +129,23 @@ contract CATValidator is EIP712, ReentrancyGuard {
     }
 
     /**
+     * @notice Transfer `amount` of `token` to `dest`.
+     * @dev Handles both ERC-20 and native ETH (token == address(0)).
+     * @param token ERC-20 token address, or address(0) for native ETH.
+     * @param amount Amount to transfer.
+     * @param dest Recipient address.
+     */
+    function _transfer(
+        address token,
+        uint256 amount,
+        address dest
+    ) internal {
+        token == address(0)
+            ? SafeTransferLib.safeTransferETH(dest, amount)
+            : SafeTransferLib.safeTransfer(token, dest, amount);
+    }
+
+    /**
      * @notice Verify this contract holds enough of each outcome token, then forward to destinations.
      * @dev The executor is expected to have transferred outcome tokens to address(this) during execution.
      *      The full held balance is forwarded, so any surplus beyond outcome.amount also goes to the destination.
@@ -144,7 +161,7 @@ contract CATValidator is EIP712, ReentrancyGuard {
             uint256 recordedPayment = _balanceOf(outcome.token, address(this));
             if (recordedPayment < outcome.amount) revert InvalidTokenAmount(outcome.amount, recordedPayment);
 
-            SafeTransferLib.safeTransfer(outcome.token, outcome.destination == address(0) ? signer : outcome.destination, recordedPayment);
+            _transfer(outcome.token, recordedPayment, outcome.destination == address(0) ? signer : outcome.destination);
         }
     }
 

--- a/solidity/src/CATValidator.sol
+++ b/solidity/src/CATValidator.sol
@@ -47,6 +47,8 @@ contract CATValidator is EIP712, ReentrancyGuard {
         CALL_PROXY = address(new CallProxy());
     }
 
+    receive() external payable { }
+
     function _domainNameAndVersion() internal pure override returns (string memory name, string memory version) {
         name = "CAT Validator";
         version = "1";

--- a/solidity/test/CATValidator.t.sol
+++ b/solidity/test/CATValidator.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import { MockERC20 } from "solady/test/utils/mocks/MockERC20.sol";
+import { SafeTransferLib } from "solady/src/utils/SafeTransferLib.sol";
 
 import { LibExecutionConstraintTest } from "./libs/LibExecutionConstraint.t.sol";
 
@@ -44,20 +45,46 @@ contract CATValidatorMock is CATValidator {
         return _call(target, payload);
     }
 
-    function recordBalances(
-        address account,
+    function validatePayment(
+        address signer,
         Outcome[] calldata outcomes
-    ) external view returns (uint256[] memory balances) {
-        return _recordBalances(account, outcomes);
+    ) external {
+        return _validatePayment(signer, outcomes);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MockExecutor — simulates a solver that can deliver tokens to CATValidator
+// (correct) or to some other address (incorrect).
+// ---------------------------------------------------------------------------
+contract MockExecutor {
+    address public immutable validator;
+
+    constructor(
+        address _validator
+    ) {
+        validator = _validator;
     }
 
-    function compareOutcomes(
-        address account,
-        Outcome[] calldata outcomes,
-        uint256[] calldata balances
-    ) external view {
-        return _compareOutcomes(account, outcomes, balances);
+    /// Sends `amount` of `token` to CATValidator — the correct behaviour.
+    function executeAndDeliverToValidator(
+        address token,
+        uint256 amount
+    ) external {
+        SafeTransferLib.safeTransfer(token, validator, amount);
     }
+
+    /// Sends `amount` of `token` to an arbitrary address — incorrect; CATValidator
+    /// receives nothing so the outcome check must fail.
+    function executeAndDeliverElsewhere(
+        address token,
+        uint256 amount,
+        address wrongDest
+    ) external {
+        SafeTransferLib.safeTransfer(token, wrongDest, amount);
+    }
+
+    receive() external payable { }
 }
 
 contract CATValidatorTest is LibExecutionConstraintTest {
@@ -66,6 +93,10 @@ contract CATValidatorTest is LibExecutionConstraintTest {
     function setUp() external {
         validator = new CATValidatorMock();
     }
+
+    // -----------------------------------------------------------------------
+    // Nonce
+    // -----------------------------------------------------------------------
 
     function test_checkNonce() external {
         address a = makeAddr("a");
@@ -83,13 +114,16 @@ contract CATValidatorTest is LibExecutionConstraintTest {
         validator.checkNonce(b, 100);
     }
 
+    // -----------------------------------------------------------------------
+    // validateApproval
+    // -----------------------------------------------------------------------
+
     function test_validateApproval(
         AllowanceSpend[] memory allowances,
         Outcome[] memory outcomes,
         address executor,
         uint256 nonce
     ) external {
-        // Tested function.
         uint8 v;
         bytes32 r;
         bytes32 s;
@@ -106,7 +140,6 @@ contract CATValidatorTest is LibExecutionConstraintTest {
             (v, r, s) = vm.sign(key, digest);
         }
 
-        // Sets msg.sender for the test
         vm.startPrank(executor);
 
         validator.validateApproval(signer, nonce, allowances, outcomes, abi.encodePacked(r, s, v));
@@ -117,6 +150,10 @@ contract CATValidatorTest is LibExecutionConstraintTest {
         vm.expectRevert(abi.encodeWithSelector(CATValidator.BadSignature.selector));
         validator.validateApproval(signer, nonce, allowances, outcomes, hex"");
     }
+
+    // -----------------------------------------------------------------------
+    // handleAllowances
+    // -----------------------------------------------------------------------
 
     function test_fuzz_handleAllowances(
         uint256[] calldata amounts
@@ -257,19 +294,20 @@ contract CATValidatorTest is LibExecutionConstraintTest {
         validator.handleAllowances(destination, account, targets);
     }
 
+    // -----------------------------------------------------------------------
+    // _call / CallProxy
+    // -----------------------------------------------------------------------
+
     function test_revert_call_transfer() external {
         address account = makeAddr("account");
         address target = makeAddr("target");
         uint256 amount = uint256(keccak256(bytes("amount")));
 
-        // set allowance to validator. This can "technically" be claimed if we could execute transferFrom from the
-        // validator.
         address token = address(new MockERC20("Test Token", "TT", 18));
         MockERC20(token).mint(account, amount);
         vm.prank(account);
         MockERC20(token).approve(address(validator), amount);
 
-        // Tell validator to execute transferFrom.
         bytes memory cd = abi.encodeCall(MockERC20.transferFrom, (account, target, amount));
 
         vm.expectCall(token, cd);
@@ -283,156 +321,387 @@ contract CATValidatorTest is LibExecutionConstraintTest {
         address proxy = validator.CALL_PROXY();
         uint256 amount = uint256(keccak256(bytes("amount")));
 
-        // set allowance to the proxy. This is bad, since anyone can call from the proxy.
         address token = address(new MockERC20("Test Token", "TT", 18));
         MockERC20(token).mint(account, amount);
         vm.prank(account);
         MockERC20(token).approve(proxy, amount);
 
-        // Tell validator to execute transferFrom.
         bytes memory cd = abi.encodeCall(MockERC20.transferFrom, (account, target, amount));
 
         vm.expectCall(token, cd);
         validator.call(token, cd);
     }
 
-    struct AmountAndDestination {
-        address destination;
-        uint128 amount;
-    }
+    // -----------------------------------------------------------------------
+    // _validatePayment
+    // -----------------------------------------------------------------------
 
-    function test_fuzz_recordBalances(
-        AmountAndDestination[] calldata ad
-    ) external {
-        address account = makeAddr("account");
-
-        Outcome[] memory outcomes = new Outcome[](ad.length);
-        for (uint256 i; i < outcomes.length; ++i) {
-            address dest = ad[i].destination == address(0) ? account : ad[i].destination;
-            if (i == 2) {
-                vm.deal(dest, ad[i].amount);
-                outcomes[i] = Outcome({ amount: ad[i].amount, destination: ad[i].destination, token: address(0) });
-                continue;
-            }
-            string memory vv = string(abi.encode(keccak256(abi.encode(i))));
-            address token = address(new MockERC20(vv, vv, 18));
-            MockERC20(token).mint(dest, ad[i].amount);
-            outcomes[i] = Outcome({ amount: ad[i].amount, destination: ad[i].destination, token: token });
-        }
-
-        uint256[] memory balances = validator.recordBalances(account, outcomes);
-
-        assertEq(balances.length, outcomes.length);
-        for (uint256 i; i < outcomes.length; ++i) {
-            assertEq(balances[i], outcomes[i].amount);
-        }
-    }
-
-    function test_fuzz_compareOutcomes(
-        AmountAndDestination[] calldata ad
-    ) external {
-        address account = makeAddr("account");
-        vm.assume(ad.length > 0);
-        vm.assume(ad[0].amount != 0);
-
-        Outcome[] memory outcomes = new Outcome[](ad.length);
-        for (uint256 i; i < outcomes.length; ++i) {
-            address dest = ad[i].destination == address(0) ? account : ad[i].destination;
-            if (i == 2) {
-                vm.deal(dest, ad[i].amount);
-                outcomes[i] = Outcome({ amount: ad[i].amount, destination: ad[i].destination, token: address(0) });
-                continue;
-            }
-            string memory vv = string(abi.encode(keccak256(abi.encode(i))));
-            address token = address(new MockERC20(vv, vv, 18));
-            MockERC20(token).mint(dest, ad[i].amount);
-            outcomes[i] = Outcome({ amount: ad[i].amount, destination: ad[i].destination, token: token });
-        }
-
-        uint256[] memory balances = validator.recordBalances(account, outcomes);
-
-        // If we run compare outcomes it should fail immediately on the first entry.
-        vm.expectRevert(abi.encodeWithSelector(CATValidator.InvalidTokenAmount.selector, ad[0].amount, 0));
-        validator.compareOutcomes(account, outcomes, balances);
-
-        // However, if we give a 0 array, then it should pass.
-        uint256[] memory zeroBalances = new uint256[](outcomes.length);
-        validator.compareOutcomes(account, outcomes, zeroBalances);
-
-        // Lets send another batch so the amounts will be 2x ad[i].amount.
-        for (uint256 i; i < outcomes.length; ++i) {
-            address dest = ad[i].destination == address(0) ? account : ad[i].destination;
-            if (i == 2) {
-                vm.deal(dest, uint256(ad[i].amount) * 2);
-
-                continue;
-            }
-            MockERC20(outcomes[i].token).mint(dest, ad[i].amount);
-        }
-
-        // Neither reverts.
-        validator.compareOutcomes(account, outcomes, balances);
-        validator.compareOutcomes(account, outcomes, zeroBalances);
-    }
-
-    function test_compareOutcomes_revert_on_wrapped_required_amount() external {
-        address account = makeAddr("account");
-        address destination = makeAddr("destination");
-        address token = address(new MockERC20("Test Token", "TT", 18));
-
-        uint256 initialBalance = 100;
-        MockERC20(token).mint(destination, initialBalance);
-
-        Outcome[] memory outcomes = new Outcome[](1);
-        outcomes[0] = Outcome({ token: token, amount: type(uint256).max, destination: destination });
-
-        uint256[] memory recordedBalances = new uint256[](1);
-        recordedBalances[0] = initialBalance;
-
-        vm.expectRevert(abi.encodeWithSelector(CATValidator.InvalidTokenAmount.selector, type(uint256).max, 0));
-        validator.compareOutcomes(account, outcomes, recordedBalances);
-    }
-
-    function test_compareOutcomes_revert_on_balance_decrease() external {
-        address account = makeAddr("account");
-        address destination = makeAddr("destination");
-        address token = address(new MockERC20("Test Token", "TT", 18));
-
-        uint256 currentBalance = 100;
-        MockERC20(token).mint(destination, currentBalance);
-
-        Outcome[] memory outcomes = new Outcome[](1);
-        outcomes[0] = Outcome({ token: token, amount: 1, destination: destination });
-
-        uint256[] memory recordedBalances = new uint256[](1);
-        recordedBalances[0] = currentBalance + 1;
-
-        vm.expectRevert(abi.encodeWithSelector(CATValidator.InvalidTokenAmount.selector, 1, 0));
-        validator.compareOutcomes(account, outcomes, recordedBalances);
-    }
-
-    // This test tests whether a decrease in balances correctly reverts.
-    // Let this contract be the signer so we can skip the allowance.
-    function test_entry_decrease_balances() external {
-        address proxy = validator.CALL_PROXY();
-
-        // Deal an account some tokens.
+    /// Executor deposits tokens to CATValidator; they are forwarded to destination.
+    function test_validatePayment_success() external {
         address dest = makeAddr("dest");
-        address token = address(new MockERC20("Test Token", "TT", 18));
-        MockERC20(token).mint(dest, 1000000000);
-        // approve the proxy so we can use the call to transfer tokens away from the user.
-        vm.prank(dest);
-        MockERC20(token).approve(proxy, 1);
+        uint256 amount = 1 ether;
 
-        // Construct a call to collect tokens from the user.
-        bytes memory call = abi.encodeCall(MockERC20.transferFrom, (dest, address(this), 1));
+        address token = address(new MockERC20("T", "T", 18));
+        MockERC20(token).mint(address(validator), amount);
 
-        AllowanceSpend[] memory allowances = new AllowanceSpend[](0);
         Outcome[] memory outcomes = new Outcome[](1);
-        outcomes[0] = Outcome({ token: token, amount: 1, destination: dest });
+        outcomes[0] = Outcome({ token: token, amount: amount, destination: dest });
 
-        vm.expectRevert();
-        validator.entry(token, call, address(this), 0, allowances, outcomes, hex"");
+        validator.validatePayment(address(this), outcomes);
+
+        assertEq(MockERC20(token).balanceOf(dest), amount);
+        assertEq(MockERC20(token).balanceOf(address(validator)), 0);
+    }
+
+    /// Executor deposits more than required; the full deposited balance is forwarded.
+    function test_validatePayment_excess_balance_forwarded() external {
+        address dest = makeAddr("dest");
+        uint256 required = 1 ether;
+        uint256 deposited = 2 ether;
+
+        address token = address(new MockERC20("T", "T", 18));
+        MockERC20(token).mint(address(validator), deposited);
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: token, amount: required, destination: dest });
+
+        validator.validatePayment(address(this), outcomes);
+
+        assertEq(MockERC20(token).balanceOf(dest), deposited);
+        assertEq(MockERC20(token).balanceOf(address(validator)), 0);
+    }
+
+    /// Multiple outcomes — each token is checked and forwarded independently.
+    function test_validatePayment_multiple_outcomes() external {
+        address destA = makeAddr("destA");
+        address destB = makeAddr("destB");
+        uint256 amountA = 1 ether;
+        uint256 amountB = 2 ether;
+
+        address tokenA = address(new MockERC20("A", "A", 18));
+        address tokenB = address(new MockERC20("B", "B", 18));
+        MockERC20(tokenA).mint(address(validator), amountA);
+        MockERC20(tokenB).mint(address(validator), amountB);
+
+        Outcome[] memory outcomes = new Outcome[](2);
+        outcomes[0] = Outcome({ token: tokenA, amount: amountA, destination: destA });
+        outcomes[1] = Outcome({ token: tokenB, amount: amountB, destination: destB });
+
+        validator.validatePayment(address(this), outcomes);
+
+        assertEq(MockERC20(tokenA).balanceOf(destA), amountA);
+        assertEq(MockERC20(tokenB).balanceOf(destB), amountB);
+    }
+
+    /// CATValidator balance below required → InvalidTokenAmount with exact values.
+    function test_validatePayment_revert_insufficient() external {
+        address dest = makeAddr("dest");
+        uint256 required = 1 ether;
+
+        address token = address(new MockERC20("T", "T", 18));
+        MockERC20(token).mint(address(validator), required - 1);
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: token, amount: required, destination: dest });
+
+        vm.expectRevert(abi.encodeWithSelector(CATValidator.InvalidTokenAmount.selector, required, required - 1));
+        validator.validatePayment(address(this), outcomes);
+    }
+
+    /// Fuzz: any non-zero amount with empty CATValidator always reverts.
+    function test_fuzz_validatePayment_revert_empty_validator(
+        uint128 amount
+    ) external {
+        vm.assume(amount > 0);
+        address dest = makeAddr("dest");
+        address token = address(new MockERC20("T", "T", 18));
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: token, amount: amount, destination: dest });
+
+        vm.expectRevert(abi.encodeWithSelector(CATValidator.InvalidTokenAmount.selector, amount, 0));
+        validator.validatePayment(address(this), outcomes);
+    }
+
+    /// Zero-amount outcome is satisfied trivially; safeTransfer(0) is a no-op.
+    function test_validatePayment_zero_amount_passes() external {
+        address dest = makeAddr("dest");
+        address token = address(new MockERC20("T", "T", 18));
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: token, amount: 0, destination: dest });
+
+        validator.validatePayment(address(this), outcomes);
+    }
+
+    /// outcome.destination == address(0) routes tokens to the signer, not to address(0).
+    function test_validatePayment_zero_destination_routes_to_signer() external {
+        address signer = makeAddr("signer");
+        uint256 amount = 1 ether;
+        address token = address(new MockERC20("T", "T", 18));
+        MockERC20(token).mint(address(validator), amount);
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: token, amount: amount, destination: address(0) });
+
+        validator.validatePayment(signer, outcomes);
+
+        assertEq(MockERC20(token).balanceOf(signer), amount);
+        assertEq(MockERC20(token).balanceOf(address(validator)), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // entry() end-to-end tests
+    // -----------------------------------------------------------------------
+
+    function _signEntry(
+        address account,
+        uint256 signerKey,
+        address executor,
+        uint256 nonce,
+        AllowanceSpend[] memory allowances,
+        Outcome[] memory outcomes
+    ) internal view returns (bytes memory sig) {
+        bytes32 th = typehashReference(allowanceSpendToAllowance(allowances), outcomes, executor, nonce);
+        bytes32 domainSeparator = EIP712(address(validator)).DOMAIN_SEPARATOR();
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, th));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, digest);
+        sig = abi.encodePacked(r, s, v);
+    }
+
+    function _setupEntryFixture(uint256 amount)
+        internal
+        returns (
+            address account,
+            uint256 key,
+            address executor,
+            address dest,
+            address inToken,
+            address outToken,
+            MockExecutor exec
+        )
+    {
+        (account, key) = makeAddrAndKey("account");
+        executor = makeAddr("executor");
+        dest = makeAddr("dest");
+
+        inToken = address(new MockERC20("In", "IN", 18));
+        outToken = address(new MockERC20("Out", "OUT", 18));
+
+        MockERC20(inToken).mint(account, amount);
+        vm.prank(account);
+        MockERC20(inToken).approve(address(validator), amount);
+
+        exec = new MockExecutor(address(validator));
+        MockERC20(outToken).mint(address(exec), amount);
+    }
+
+    /// Happy path: executor delivers outcome tokens to CATValidator;
+    /// CATValidator forwards them to destination.
+    function test_entry_success() external {
+        uint256 amount = 1 ether;
+        (
+            address account,
+            uint256 key,
+            address executor,
+            address dest,
+            address inToken,
+            address outToken,
+            MockExecutor exec
+        ) = _setupEntryFixture(amount);
+
+        AllowanceSpend[] memory allowances = new AllowanceSpend[](1);
+        allowances[0] = AllowanceSpend({ token: inToken, allocated: amount, spend: amount });
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: outToken, amount: amount, destination: dest });
+
+        bytes memory sig = _signEntry(account, key, executor, 1, allowances, outcomes);
+        bytes memory execPayload = abi.encodeCall(MockExecutor.executeAndDeliverToValidator, (outToken, amount));
+
+        vm.prank(executor);
+        validator.entry(address(exec), execPayload, account, 1, allowances, outcomes, sig);
+
+        assertEq(MockERC20(outToken).balanceOf(dest), amount);
+        assertEq(MockERC20(inToken).balanceOf(address(exec)), amount);
+        assertEq(MockERC20(outToken).balanceOf(address(validator)), 0);
+    }
+
+    /// Executor sends output tokens to a wrong address; CATValidator holds nothing → revert.
+    function test_entry_executor_sends_to_wrong_address_reverts() external {
+        uint256 amount = 1 ether;
+        (
+            address account,
+            uint256 key,
+            address executor,
+            address dest,
+            address inToken,
+            address outToken,
+            MockExecutor exec
+        ) = _setupEntryFixture(amount);
+
+        address wrongDest = makeAddr("wrongDest");
+
+        AllowanceSpend[] memory allowances = new AllowanceSpend[](1);
+        allowances[0] = AllowanceSpend({ token: inToken, allocated: amount, spend: amount });
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: outToken, amount: amount, destination: dest });
+
+        bytes memory sig = _signEntry(account, key, executor, 1, allowances, outcomes);
+        bytes memory execPayload =
+            abi.encodeCall(MockExecutor.executeAndDeliverElsewhere, (outToken, amount, wrongDest));
+
+        vm.prank(executor);
+        vm.expectRevert(abi.encodeWithSelector(CATValidator.InvalidTokenAmount.selector, amount, 0));
+        validator.entry(address(exec), execPayload, account, 1, allowances, outcomes, sig);
+    }
+
+    /// Wrong executor (msg.sender ≠ signed executor) → BadSignature before any state change.
+    function test_entry_bad_executor_reverts() external {
+        uint256 amount = 1 ether;
+        (
+            address account,
+            uint256 key,
+            address executor,
+            address dest,
+            address inToken,
+            address outToken,
+            MockExecutor exec
+        ) = _setupEntryFixture(amount);
+
+        AllowanceSpend[] memory allowances = new AllowanceSpend[](1);
+        allowances[0] = AllowanceSpend({ token: inToken, allocated: amount, spend: amount });
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: outToken, amount: amount, destination: dest });
+
+        bytes memory sig = _signEntry(account, key, executor, 1, allowances, outcomes);
+        bytes memory execPayload = abi.encodeCall(MockExecutor.executeAndDeliverToValidator, (outToken, amount));
+
+        vm.prank(makeAddr("wrongCaller"));
+        vm.expectRevert(abi.encodeWithSelector(CATValidator.BadSignature.selector));
+        validator.entry(address(exec), execPayload, account, 1, allowances, outcomes, sig);
+    }
+
+    /// Non-zero nonce is consumed after a successful call; replaying reverts with NonceAlreadySpent.
+    function test_entry_nonce_consumed_after_success() external {
+        uint256 amount = 1 ether;
+        (
+            address account,
+            uint256 key,
+            address executor,
+            address dest,
+            address inToken,
+            address outToken,
+            MockExecutor exec
+        ) = _setupEntryFixture(amount);
+
+        // Mint extra so the second call can also attempt allowances.
+        MockERC20(inToken).mint(account, amount);
+        vm.prank(account);
+        MockERC20(inToken).approve(address(validator), amount * 2);
+        MockERC20(outToken).mint(address(exec), amount);
+
+        AllowanceSpend[] memory allowances = new AllowanceSpend[](1);
+        allowances[0] = AllowanceSpend({ token: inToken, allocated: amount, spend: amount });
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: outToken, amount: amount, destination: dest });
+
+        bytes memory sig = _signEntry(account, key, executor, 1, allowances, outcomes);
+        bytes memory execPayload = abi.encodeCall(MockExecutor.executeAndDeliverToValidator, (outToken, amount));
+
+        vm.prank(executor);
+        validator.entry(address(exec), execPayload, account, 1, allowances, outcomes, sig);
+
+        vm.prank(executor);
+        vm.expectRevert(abi.encodeWithSelector(CATValidator.NonceAlreadySpent.selector));
+        validator.entry(address(exec), execPayload, account, 1, allowances, outcomes, sig);
+    }
+
+    /// Nonce 0 is never stored — can be used for long-lived approvals (e.g. DCAs).
+    function test_entry_nonce_zero_is_long_lived() external {
+        uint256 amount = 1 ether;
+        (
+            address account,
+            uint256 key,
+            address executor,
+            address dest,
+            address inToken,
+            address outToken,
+            MockExecutor exec
+        ) = _setupEntryFixture(amount);
+
+        // Mint enough for two rounds.
+        MockERC20(inToken).mint(account, amount);
+        vm.prank(account);
+        MockERC20(inToken).approve(address(validator), amount * 2);
+        MockERC20(outToken).mint(address(exec), amount);
+
+        AllowanceSpend[] memory allowances = new AllowanceSpend[](1);
+        allowances[0] = AllowanceSpend({ token: inToken, allocated: amount, spend: amount });
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: outToken, amount: amount, destination: dest });
+
+        bytes memory sig = _signEntry(account, key, executor, 0, allowances, outcomes);
+        bytes memory execPayload = abi.encodeCall(MockExecutor.executeAndDeliverToValidator, (outToken, amount));
+
+        // First call succeeds.
+        vm.prank(executor);
+        validator.entry(address(exec), execPayload, account, 0, allowances, outcomes, sig);
+
+        // Second call with nonce 0 also succeeds — no NonceAlreadySpent.
+        vm.prank(executor);
+        validator.entry(address(exec), execPayload, account, 0, allowances, outcomes, sig);
+
+        assertEq(MockERC20(outToken).balanceOf(dest), amount * 2);
+    }
+
+    /// A reverted transaction rolls back the nonce; the same nonce can be retried.
+    function test_entry_nonce_not_consumed_on_revert() external {
+        uint256 amount = 1 ether;
+        (
+            address account,
+            uint256 key,
+            address executor,
+            address dest,
+            address inToken,
+            address outToken,
+            MockExecutor exec
+        ) = _setupEntryFixture(amount);
+
+        // Mint extra for the second attempt.
+        MockERC20(inToken).mint(account, amount);
+        vm.prank(account);
+        MockERC20(inToken).approve(address(validator), amount * 2);
+        MockERC20(outToken).mint(address(exec), amount);
+
+        AllowanceSpend[] memory allowances = new AllowanceSpend[](1);
+        allowances[0] = AllowanceSpend({ token: inToken, allocated: amount, spend: amount });
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: outToken, amount: amount, destination: dest });
+
+        bytes memory sig = _signEntry(account, key, executor, 1, allowances, outcomes);
+        // Wrong delivery: executor sends to wrongDest, CATValidator gets nothing.
+        address wrongDest = makeAddr("wrongDest");
+        bytes memory failPayload =
+            abi.encodeCall(MockExecutor.executeAndDeliverElsewhere, (outToken, amount, wrongDest));
+        bytes memory goodPayload = abi.encodeCall(MockExecutor.executeAndDeliverToValidator, (outToken, amount));
+
+        // First call: fails at _validatePayment → all state rolled back including nonce.
+        vm.prank(executor);
+        vm.expectRevert(abi.encodeWithSelector(CATValidator.InvalidTokenAmount.selector, amount, 0));
+        validator.entry(address(exec), failPayload, account, 1, allowances, outcomes, sig);
+
+        // Second call: nonce 1 is available again; executor delivers correctly this time.
+        MockERC20(outToken).mint(address(exec), amount); // replenish exec's outToken
+        vm.prank(executor);
+        validator.entry(address(exec), goodPayload, account, 1, allowances, outcomes, sig);
+
+        assertEq(MockERC20(outToken).balanceOf(dest), amount);
     }
 
     function isValidSignature(

--- a/solidity/test/CATValidator.t.sol
+++ b/solidity/test/CATValidator.t.sol
@@ -704,10 +704,87 @@ contract CATValidatorTest is LibExecutionConstraintTest {
         assertEq(MockERC20(outToken).balanceOf(dest), amount);
     }
 
+    // -----------------------------------------------------------------------
+    // _validatePayment — native ETH outcomes
+    // -----------------------------------------------------------------------
+
+    /// Executor deposits ETH to CATValidator; it is forwarded to destination.
+    function test_validatePayment_nativeETH_success() external {
+        address dest = makeAddr("dest");
+        uint256 amount = 1 ether;
+
+        vm.deal(address(validator), amount);
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: address(0), amount: amount, destination: dest });
+
+        uint256 destBefore = dest.balance;
+        validator.validatePayment(address(this), outcomes);
+
+        assertEq(dest.balance - destBefore, amount);
+        assertEq(address(validator).balance, 0);
+    }
+
+    /// ETH outcome with address(0) destination routes to signer.
+    function test_validatePayment_nativeETH_zero_destination_routes_to_signer() external {
+        address signer = makeAddr("signer");
+        uint256 amount = 1 ether;
+
+        vm.deal(address(validator), amount);
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: address(0), amount: amount, destination: address(0) });
+
+        uint256 signerBefore = signer.balance;
+        validator.validatePayment(signer, outcomes);
+
+        assertEq(signer.balance - signerBefore, amount);
+        assertEq(address(validator).balance, 0);
+    }
+
+    /// ETH balance below required → InvalidTokenAmount.
+    function test_validatePayment_nativeETH_revert_insufficient() external {
+        address dest = makeAddr("dest");
+        uint256 required = 1 ether;
+
+        vm.deal(address(validator), required - 1);
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: address(0), amount: required, destination: dest });
+
+        vm.expectRevert(abi.encodeWithSelector(CATValidator.InvalidTokenAmount.selector, required, required - 1));
+        validator.validatePayment(address(this), outcomes);
+    }
+
+    /// Mixed ETH + ERC-20 outcomes in a single call.
+    function test_validatePayment_mixed_eth_and_erc20() external {
+        address destETH = makeAddr("destETH");
+        address destERC = makeAddr("destERC");
+        uint256 ethAmount = 0.5 ether;
+        uint256 ercAmount = 100e18;
+
+        vm.deal(address(validator), ethAmount);
+        address token = address(new MockERC20("T", "T", 18));
+        MockERC20(token).mint(address(validator), ercAmount);
+
+        Outcome[] memory outcomes = new Outcome[](2);
+        outcomes[0] = Outcome({ token: address(0), amount: ethAmount, destination: destETH });
+        outcomes[1] = Outcome({ token: token, amount: ercAmount, destination: destERC });
+
+        validator.validatePayment(address(this), outcomes);
+
+        assertEq(destETH.balance, ethAmount);
+        assertEq(MockERC20(token).balanceOf(destERC), ercAmount);
+        assertEq(address(validator).balance, 0);
+        assertEq(MockERC20(token).balanceOf(address(validator)), 0);
+    }
+
     function isValidSignature(
         bytes32,
         bytes calldata
     ) public view returns (bytes4) {
         return bytes4(0x1626ba7e);
     }
+
+    receive() external payable { }
 }

--- a/solidity/test/CATValidator.t.sol
+++ b/solidity/test/CATValidator.t.sol
@@ -84,6 +84,13 @@ contract MockExecutor {
         SafeTransferLib.safeTransfer(token, wrongDest, amount);
     }
 
+    /// Sends ETH to CATValidator — for testing native ETH output outcomes.
+    function executeAndDeliverETHToValidator(
+        uint256 amount
+    ) external {
+        SafeTransferLib.safeTransferETH(validator, amount);
+    }
+
     receive() external payable { }
 }
 
@@ -702,6 +709,44 @@ contract CATValidatorTest is LibExecutionConstraintTest {
         validator.entry(address(exec), goodPayload, account, 1, allowances, outcomes, sig);
 
         assertEq(MockERC20(outToken).balanceOf(dest), amount);
+    }
+
+    /// ERC-20 input, native ETH output: signer approves an ERC-20 and requests ETH back.
+    /// Executor is pre-loaded with ETH and delivers it to CATValidator; validator forwards to dest.
+    function test_entry_erc20_in_eth_out() external {
+        uint256 amount = 1 ether;
+        (address account, uint256 key) = makeAddrAndKey("account");
+        address executor = makeAddr("executor");
+        address dest = makeAddr("dest");
+
+        // Input: random ERC-20 approved by signer to validator
+        address inToken = address(new MockERC20("In", "IN", 18));
+        MockERC20(inToken).mint(account, amount);
+        vm.prank(account);
+        MockERC20(inToken).approve(address(validator), amount);
+
+        // Executor holds ETH that it will "swap" and deliver
+        MockExecutor exec = new MockExecutor(address(validator));
+        vm.deal(address(exec), amount);
+
+        AllowanceSpend[] memory allowances = new AllowanceSpend[](1);
+        allowances[0] = AllowanceSpend({ token: inToken, allocated: amount, spend: amount });
+
+        // Output: native ETH to dest
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: address(0), amount: amount, destination: dest });
+
+        bytes memory sig = _signEntry(account, key, executor, 1, allowances, outcomes);
+        bytes memory execPayload = abi.encodeCall(MockExecutor.executeAndDeliverETHToValidator, (amount));
+
+        uint256 destBefore = dest.balance;
+        vm.prank(executor);
+        validator.entry(address(exec), execPayload, account, 1, allowances, outcomes, sig);
+
+        // ETH forwarded to dest, validator drained, executor received the ERC-20
+        assertEq(dest.balance - destBefore, amount);
+        assertEq(address(validator).balance, 0);
+        assertEq(MockERC20(inToken).balanceOf(address(exec)), amount);
     }
 
     // -----------------------------------------------------------------------

--- a/solidity/test/Integration.t.sol
+++ b/solidity/test/Integration.t.sol
@@ -61,6 +61,7 @@ contract IntegrationTest is LibExecutionConstraintTest {
     CATValidator validator;
 
     MockERC20 validatorToken;
+    address validatorAddress;
     uint256 balanceOfSwap = 0;
 
     function setUp() external {
@@ -270,6 +271,7 @@ contract IntegrationTest is LibExecutionConstraintTest {
 
     function test_validator() external {
         validatorToken = new MockERC20("Outcome Token", "OutTok", 18);
+        validatorAddress = address(validator);
 
         (address user,) = makeAddrAndKey("user");
 
@@ -333,8 +335,10 @@ contract IntegrationTest is LibExecutionConstraintTest {
         inputTargets[0] = AllowanceSpend({
             token: allowances[0].token, allocated: allowances[0].amount, spend: allowances[0].amount
         });
+        // Pass the CATValidator address so swap() delivers output tokens there,
+        // not to the final destination (which would leave CATValidator with nothing).
         bytes memory externalCall =
-            abi.encodeCall(this.swap, (allowances[0].amount, allowances[0].token, outcomes[0].destination));
+            abi.encodeCall(this.swap, (allowances[0].amount, allowances[0].token, address(validator)));
 
         vm.prank(makeAddr("WrongCaller"));
         vm.expectRevert(abi.encodeWithSelector(CATValidator.BadSignature.selector));
@@ -342,19 +346,136 @@ contract IntegrationTest is LibExecutionConstraintTest {
 
         vm.prank(constraint.executor);
         validator.entry(address(this), externalCall, proxy, constraint.nonce, inputTargets, outcomes, hex"");
+
+        assertEq(validatorToken.balanceOf(outcomes[0].destination), outcomes[0].amount);
     }
 
-    // Mock functions for exchanging 1 token for another
+    // -----------------------------------------------------------------------
+    // Audit 6.1.1 integration tests — full multicall path
+    // -----------------------------------------------------------------------
+
+    /// Shared setup: deploy a Catapultar account that has pre-approved `validator`
+    /// to spend its allowance token and pre-registered the execution constraint digest
+    /// via setSignature. Returns the account proxy and the prepared calldata pieces.
+    ///
+    /// The execution constraint uses nonce 0 (long-lived) so the CATValidator
+    /// accepts `hex""` as signature via the account's EIP-1271 isValidSignature path.
+    function _deployConstrainedProxy(
+        address executor,
+        address user
+    )
+        internal
+        returns (
+            address payable proxy,
+            AllowanceSpend[] memory inputTargets,
+            Outcome[] memory outcomes
+        )
+    {
+        uint256 amount = 10 ** 18;
+        address allowanceToken = address(new MockERC20("Allowance Token", "IT", 18));
+
+        Allowance[] memory allowances = new Allowance[](1);
+        allowances[0] = Allowance({ amount: amount, token: allowanceToken });
+        outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: address(validatorToken), amount: amount, destination: user });
+
+        // Build the EIP-712 digest for the constraint so the account can store it.
+        bytes32 th = typehashReference(allowances, outcomes, executor, 0);
+        bytes32 domainSeparator = EIP712(address(validator)).DOMAIN_SEPARATOR();
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, th));
+
+        // Batch: approve validator + call setSignature on the account itself.
+        ERC7821.Call[] memory calls = new ERC7821.Call[](2);
+        calls[0] = ERC7821.Call({
+            to: allowanceToken,
+            data: abi.encodeWithSignature("approve(address,uint256)", address(validator), amount),
+            value: 0
+        });
+        calls[1] = ERC7821.Call({
+            to: address(0), // self
+            data: abi.encodeCall(Catapultar.setSignature, (digest, Catapultar.DigestApproval.Signature)),
+            value: 0
+        });
+
+        bytes32[] memory keys = new bytes32[](1);
+        keys[0] = bytes32(uint256(uint160(user)));
+        proxy = factory.deployWithDigest(
+            KeyedOwnable.PublicKeyType.ECDSAOrSmartContract,
+            keys,
+            bytes32(bytes20(uint160(user))),
+            this.typehash(1, REVERT_MODE, calls),
+            false
+        );
+
+        // Execute the approve + setSignature batch on the freshly deployed account.
+        Catapultar(proxy).execute(REVERT_MODE, abi.encode(calls, abi.encodePacked(uint256(1))));
+
+        // Fund the account with the allowance token.
+        MockERC20(allowanceToken).mint(proxy, amount);
+
+        inputTargets = new AllowanceSpend[](1);
+        inputTargets[0] =
+            AllowanceSpend({ token: allowanceToken, allocated: amount, spend: amount });
+    }
+
+    /// Audit 6.1.1: executor calls swap(), which mints output tokens directly to the
+    /// outcome destination during execution. CATValidator receives nothing.
+    /// The outcome check must fail even though `dest` was paid via the external call.
+    function test_audit_611_swap_mints_to_dest_rejected() external {
+        validatorToken = new MockERC20("Outcome Token", "OutTok", 18);
+
+        address user = makeAddr("user");
+        address executor = makeAddr("executor");
+
+        (address payable proxy, AllowanceSpend[] memory inputTargets, Outcome[] memory outcomes) =
+            _deployConstrainedProxy(executor, user);
+
+        // swap() mints validatorToken to `user` — not to CATValidator.
+        bytes memory externalCall =
+            abi.encodeCall(this.swap, (inputTargets[0].spend, inputTargets[0].token, user));
+
+        vm.prank(executor);
+        vm.expectRevert(
+            abi.encodeWithSelector(CATValidator.InvalidTokenAmount.selector, outcomes[0].amount, 0)
+        );
+        validator.entry(address(this), externalCall, proxy, 0, inputTargets, outcomes, hex"");
+    }
+
+    /// Audit 6.1.1 correct path: executor calls swap(), which mints output tokens to
+    /// CATValidator during execution. Outcome check passes and tokens are forwarded to dest.
+    function test_audit_611_swap_mints_to_validator_accepted() external {
+        validatorToken = new MockERC20("Outcome Token", "OutTok", 18);
+
+        address user = makeAddr("user");
+        address executor = makeAddr("executor");
+
+        (address payable proxy, AllowanceSpend[] memory inputTargets, Outcome[] memory outcomes) =
+            _deployConstrainedProxy(executor, user);
+
+        // swap() mints validatorToken to CATValidator — correct delivery path.
+        bytes memory externalCall =
+            abi.encodeCall(this.swap, (inputTargets[0].spend, inputTargets[0].token, address(validator)));
+
+        vm.prank(executor);
+        validator.entry(address(this), externalCall, proxy, 0, inputTargets, outcomes, hex"");
+
+        assertEq(validatorToken.balanceOf(user), outcomes[0].amount);
+        assertEq(validatorToken.balanceOf(address(validator)), 0);
+    }
+
+    // Mock functions for exchanging 1 token for another.
+    // `deliverTo` must be the CATValidator address so _validatePayment can read
+    // its own balance and then forward tokens to the final outcome destination.
     function swap(
         uint256 amount,
         address inToken,
-        address target
+        address deliverTo
     ) external {
         // Check for balance increase.
         uint256 diff = MockERC20(inToken).balanceOf(address(this)) - balanceOfSwap;
         balanceOfSwap += diff;
 
-        validatorToken.mint(target, amount);
+        validatorToken.mint(deliverTo, amount);
     }
 
     function typehash(

--- a/solidity/test/helpers/CATValidator.t.sol
+++ b/solidity/test/helpers/CATValidator.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import { MockERC20 } from "solady/test/utils/mocks/MockERC20.sol";
+import { SafeTransferLib } from "solady/src/utils/SafeTransferLib.sol";
 
 import { LibExecutionConstraintTest } from "./libs/LibExecutionConstraint.t.sol";
 
@@ -10,6 +11,18 @@ import { AllowanceSpend, Outcome } from "../../src/libs/LibExecutionConstraint.s
 
 interface EIP712 {
     function DOMAIN_SEPARATOR() external view returns (bytes32);
+}
+
+/// Simulates an external protocol (swap router, airdrop, OpenSea settlement, etc.)
+/// that holds output tokens and can send them to any address during execution.
+contract MockTokenSender {
+    function sendTo(
+        address token,
+        uint256 amount,
+        address recipient
+    ) external {
+        SafeTransferLib.safeTransfer(token, recipient, amount);
+    }
 }
 
 contract CATValidatorMock is CATValidator {
@@ -47,19 +60,11 @@ contract CATValidatorMock is CATValidator {
         return _call(target, payload);
     }
 
-    function recordBalances(
-        address account,
+    function validatePayment(
+        address signer,
         Outcome[] calldata outcomes
-    ) external view returns (uint256[] memory balances) {
-        return _recordBalances(account, outcomes);
-    }
-
-    function compareOutcomes(
-        address account,
-        Outcome[] calldata outcomes,
-        uint256[] calldata balances
-    ) external view {
-        return _compareOutcomes(account, outcomes, balances);
+    ) external {
+        return _validatePayment(signer, outcomes);
     }
 }
 
@@ -69,6 +74,10 @@ contract CATValidatorTest is LibExecutionConstraintTest {
     function setUp() external {
         validator = new CATValidatorMock();
     }
+
+    // -----------------------------------------------------------------------
+    // Nonce
+    // -----------------------------------------------------------------------
 
     function test_checkNonce() external {
         address a = makeAddr("a");
@@ -86,13 +95,16 @@ contract CATValidatorTest is LibExecutionConstraintTest {
         validator.checkNonce(b, 100);
     }
 
+    // -----------------------------------------------------------------------
+    // validateApproval
+    // -----------------------------------------------------------------------
+
     function test_validateApproval(
         AllowanceSpend[] memory allowances,
         Outcome[] memory outcomes,
         address executor,
         uint256 nonce
     ) external {
-        // Tested function.
         uint8 v;
         bytes32 r;
         bytes32 s;
@@ -109,7 +121,6 @@ contract CATValidatorTest is LibExecutionConstraintTest {
             (v, r, s) = vm.sign(key, digest);
         }
 
-        // Sets msg.sender for the test
         vm.startPrank(executor);
 
         validator.validateApproval(signer, nonce, allowances, outcomes, abi.encodePacked(r, s, v));
@@ -120,6 +131,10 @@ contract CATValidatorTest is LibExecutionConstraintTest {
         vm.expectRevert(abi.encodeWithSelector(CATValidator.BadSignature.selector));
         validator.validateApproval(signer, nonce, allowances, outcomes, hex"");
     }
+
+    // -----------------------------------------------------------------------
+    // handleAllowances
+    // -----------------------------------------------------------------------
 
     function test_fuzz_handleAllowances(
         uint256[] calldata amounts
@@ -235,19 +250,20 @@ contract CATValidatorTest is LibExecutionConstraintTest {
         validator.handleAllowances(destination, account, allowances);
     }
 
+    // -----------------------------------------------------------------------
+    // _call / CallProxy
+    // -----------------------------------------------------------------------
+
     function test_revert_call_transfer() external {
         address account = makeAddr("account");
         address target = makeAddr("target");
         uint256 amount = uint256(keccak256(bytes("amount")));
 
-        // set allowance to validator. This can "technically" be claimed if we could execute transferFrom from the
-        // validator.
         address token = address(new MockERC20("Test Token", "TT", 18));
         MockERC20(token).mint(account, amount);
         vm.prank(account);
         MockERC20(token).approve(address(validator), amount);
 
-        // Tell validator to execute transferFrom.
         bytes memory cd = abi.encodeCall(MockERC20.transferFrom, (account, target, amount));
 
         vm.expectCall(token, cd);
@@ -261,95 +277,149 @@ contract CATValidatorTest is LibExecutionConstraintTest {
         address proxy = validator.CALL_PROXY();
         uint256 amount = uint256(keccak256(bytes("amount")));
 
-        // set allowance to the proxy. This is bad, since anyone can call from the proxy.
         address token = address(new MockERC20("Test Token", "TT", 18));
         MockERC20(token).mint(account, amount);
         vm.prank(account);
         MockERC20(token).approve(proxy, amount);
 
-        // Tell validator to execute transferFrom.
         bytes memory cd = abi.encodeCall(MockERC20.transferFrom, (account, target, amount));
 
         vm.expectCall(token, cd);
         validator.call(token, cd);
     }
 
-    struct AmountAndDestination {
-        address destination;
-        uint128 amount;
+    // -----------------------------------------------------------------------
+    // _validatePayment
+    // -----------------------------------------------------------------------
+
+    /// Executor deposits tokens to CATValidator; they are forwarded to destination.
+    function test_validatePayment_success() external {
+        address dest = makeAddr("dest");
+        uint256 amount = 1 ether;
+        address token = address(new MockERC20("T", "T", 18));
+
+        MockERC20(token).mint(address(validator), amount);
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: token, amount: amount, destination: dest });
+
+        validator.validatePayment(address(this), outcomes);
+
+        assertEq(MockERC20(token).balanceOf(dest), amount);
+        assertEq(MockERC20(token).balanceOf(address(validator)), 0);
     }
 
-    function test_fuzz_recordBalances(
-        AmountAndDestination[] calldata ad
-    ) external {
-        address account = makeAddr("account");
+    /// CATValidator holds less than required → exact InvalidTokenAmount.
+    function test_validatePayment_revert_insufficient() external {
+        address dest = makeAddr("dest");
+        uint256 required = 1 ether;
+        address token = address(new MockERC20("T", "T", 18));
 
-        Outcome[] memory outcomes = new Outcome[](ad.length);
-        for (uint256 i; i < outcomes.length; ++i) {
-            address dest = ad[i].destination == address(0) ? account : ad[i].destination;
-            if (i == 2) {
-                vm.deal(dest, ad[i].amount);
-                outcomes[i] = Outcome({ amount: ad[i].amount, destination: ad[i].destination, token: address(0) });
-                continue;
-            }
-            string memory vv = string(abi.encode(keccak256(abi.encode(i))));
-            address token = address(new MockERC20(vv, vv, 18));
-            MockERC20(token).mint(dest, ad[i].amount);
-            outcomes[i] = Outcome({ amount: ad[i].amount, destination: ad[i].destination, token: token });
-        }
+        MockERC20(token).mint(address(validator), required - 1);
 
-        uint256[] memory balances = validator.recordBalances(account, outcomes);
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: token, amount: required, destination: dest });
 
-        assertEq(balances.length, outcomes.length);
-        for (uint256 i; i < outcomes.length; ++i) {
-            assertEq(balances[i], outcomes[i].amount);
-        }
+        vm.expectRevert(abi.encodeWithSelector(CATValidator.InvalidTokenAmount.selector, required, required - 1));
+        validator.validatePayment(address(this), outcomes);
     }
 
-    function test_fuzz_compareOutcomes(
-        AmountAndDestination[] calldata ad
-    ) external {
-        address account = makeAddr("account");
-        vm.assume(ad.length > 0);
-        vm.assume(ad[0].amount != 0);
+    /// Zero-amount outcome passes trivially.
+    function test_validatePayment_zero_amount_passes() external {
+        address dest = makeAddr("dest");
+        address token = address(new MockERC20("T", "T", 18));
 
-        Outcome[] memory outcomes = new Outcome[](ad.length);
-        for (uint256 i; i < outcomes.length; ++i) {
-            address dest = ad[i].destination == address(0) ? account : ad[i].destination;
-            if (i == 2) {
-                vm.deal(dest, ad[i].amount);
-                outcomes[i] = Outcome({ amount: ad[i].amount, destination: ad[i].destination, token: address(0) });
-                continue;
-            }
-            string memory vv = string(abi.encode(keccak256(abi.encode(i))));
-            address token = address(new MockERC20(vv, vv, 18));
-            MockERC20(token).mint(dest, ad[i].amount);
-            outcomes[i] = Outcome({ amount: ad[i].amount, destination: ad[i].destination, token: token });
-        }
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: token, amount: 0, destination: dest });
 
-        uint256[] memory balances = validator.recordBalances(account, outcomes);
+        validator.validatePayment(address(this), outcomes);
+    }
 
-        // If we run compareOutcomes it should fail immediately on the first entry.
-        vm.expectRevert(abi.encodeWithSelector(CATValidator.InvalidTokenAmount.selector, ad[0].amount, 0));
-        validator.compareOutcomes(account, outcomes, balances);
+    // -----------------------------------------------------------------------
+    // Audit 6.1.1 regression tests
+    // -----------------------------------------------------------------------
 
-        // However, if we give a 0 array, then it should pass.
-        uint256[] memory zeroBalances = new uint256[](outcomes.length);
-        validator.compareOutcomes(account, outcomes, zeroBalances);
+    function _signEntry(
+        address account,
+        uint256 signerKey,
+        address executor,
+        uint256 nonce,
+        AllowanceSpend[] memory allowances,
+        Outcome[] memory outcomes
+    ) internal view returns (bytes memory sig) {
+        bytes32 th = typehashReference(allowances, outcomes, executor, nonce);
+        bytes32 domainSeparator = EIP712(address(validator)).DOMAIN_SEPARATOR();
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, th));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerKey, digest);
+        sig = abi.encodePacked(r, s, v);
+    }
 
-        // Lets send another batch so the amounts will be 2x ad[i].amount.
-        for (uint256 i; i < outcomes.length; ++i) {
-            address dest = ad[i].destination == address(0) ? account : ad[i].destination;
-            if (i == 2) {
-                vm.deal(dest, uint256(ad[i].amount) * 2);
+    /// During real execution a mock protocol sends output tokens to `dest` directly.
+    /// CATValidator receives nothing → outcome check fails even though dest was paid.
+    function test_audit_611_execution_delivers_to_dest_rejected() external {
+        (address account, uint256 key) = makeAddrAndKey("account");
+        address executor = makeAddr("executor");
+        address dest = makeAddr("dest");
+        uint256 amount = 1 ether;
 
-                continue;
-            }
-            MockERC20(outcomes[i].token).mint(dest, ad[i].amount);
-        }
+        address inToken = address(new MockERC20("In", "IN", 18));
+        address outToken = address(new MockERC20("Out", "OUT", 18));
 
-        // Neither reverts.
-        validator.compareOutcomes(account, outcomes, balances);
-        validator.compareOutcomes(account, outcomes, zeroBalances);
+        MockERC20(inToken).mint(account, amount);
+        vm.prank(account);
+        MockERC20(inToken).approve(address(validator), amount);
+
+        // MockTokenSender holds output tokens and will send them wherever told.
+        MockTokenSender sender = new MockTokenSender();
+        MockERC20(outToken).mint(address(sender), amount);
+
+        AllowanceSpend[] memory allowances = new AllowanceSpend[](1);
+        allowances[0] = AllowanceSpend({ token: inToken, allocated: amount, spend: amount });
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: outToken, amount: amount, destination: dest });
+
+        bytes memory sig = _signEntry(account, key, executor, 1, allowances, outcomes);
+        // Executor instructs sender to deliver to `dest` — not to CATValidator.
+        bytes memory execPayload = abi.encodeCall(MockTokenSender.sendTo, (outToken, amount, dest));
+
+        vm.prank(executor);
+        vm.expectRevert(abi.encodeWithSelector(CATValidator.InvalidTokenAmount.selector, amount, 0));
+        validator.entry(address(sender), execPayload, account, 1, allowances, outcomes, sig);
+    }
+
+    /// During real execution a mock protocol sends output tokens to CATValidator.
+    /// Outcome check passes and tokens are forwarded to `dest`.
+    function test_audit_611_execution_delivers_to_validator_accepted() external {
+        (address account, uint256 key) = makeAddrAndKey("account");
+        address executor = makeAddr("executor");
+        address dest = makeAddr("dest");
+        uint256 amount = 1 ether;
+
+        address inToken = address(new MockERC20("In", "IN", 18));
+        address outToken = address(new MockERC20("Out", "OUT", 18));
+
+        MockERC20(inToken).mint(account, amount);
+        vm.prank(account);
+        MockERC20(inToken).approve(address(validator), amount);
+
+        MockTokenSender sender = new MockTokenSender();
+        MockERC20(outToken).mint(address(sender), amount);
+
+        AllowanceSpend[] memory allowances = new AllowanceSpend[](1);
+        allowances[0] = AllowanceSpend({ token: inToken, allocated: amount, spend: amount });
+
+        Outcome[] memory outcomes = new Outcome[](1);
+        outcomes[0] = Outcome({ token: outToken, amount: amount, destination: dest });
+
+        bytes memory sig = _signEntry(account, key, executor, 1, allowances, outcomes);
+        // Executor instructs sender to deliver to CATValidator — correct.
+        bytes memory execPayload = abi.encodeCall(MockTokenSender.sendTo, (outToken, amount, address(validator)));
+
+        vm.prank(executor);
+        validator.entry(address(sender), execPayload, account, 1, allowances, outcomes, sig);
+
+        assertEq(MockERC20(outToken).balanceOf(dest), amount);
+        assertEq(MockERC20(outToken).balanceOf(address(validator)), 0);
     }
 }


### PR DESCRIPTION
Fixes audit finding 6.1.1 — CATValidator previously validated outcomes by diffing the balance at outcome.destination before/after execution, allowing unrelated balance increases (airdrops, NFT sales) to satisfy outcome requirements.

**This is a breaking change for our use case and we need to update the target of the tokens during the delivery phase.**

### Contract change (`CATValidator.sol`):
- Removed `_recordBalances` / `_compareOutcomes` (diff-based approach)
- Executor must now deposit output tokens to the `CATValidator` contract during execution
- `_validatePayment` checks `CATValidator`'s own balance, then forwards to `outcome.destination`
- `outcome.destination == address(0)` routes to the account signer.

### Tests:
- Integration tests in `Integration.t.sol` cover the full path: Catapultar account → `ERC7821` multicall (`approve` + `setSignature`) → `validator.entry()` → mock swap mints
tokens → outcome validated
- `test_audit_611_swap_mints_to_dest_rejected`: swap delivers to dest during execution → InvalidTokenAmount despite dest being paid
- `test_audit_611_swap_mints_to_validator_accepted`: swap delivers to CATValidator → tokens forwarded correctly