### PR TITLE
(audit 6.4.2) Incorrect NatDoc: `entry()` documents spend = 0 as balance-of magic value

### DIFF
--- a/solidity/src/CATValidator.sol
+++ b/solidity/src/CATValidator.sol
@@ -61,8 +61,8 @@ contract CATValidator is EIP712, ReentrancyGuard {
      * @dev This function can only be called by the designated executor. The caller check is made by embedding
      * msg.sender as the executor in the typehash. This contract does not support _any_ executor and one has to be
      * provided.
-     * If a destination is address(0), it specifies the signer. If a spend is 0 the current balance of the signer will
-     * be used.
+     * If a destination is address(0), it specifies the signer. If a spend is 1 << 255 (SPEND_BALANCE_OF_MAGIC), the
+     * current balance of the signer will be used.
      */
     function entry(
         address execTarget,


### PR DESCRIPTION
Documentation specifies 0 as the magic value for using the entire spend balance. The true value is `1 << 255`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TypeScript SDK with transaction builders and account management for Catapultar smart accounts.
  * Introduced support for multiple key types: ECDSA, P256, and WebAuthn P256 authentication.
  * Added CAT Validator contract for constrained asset transactions with allowance and outcome validation.
  * Added Intent Executor for multicall batch execution with token sweeping.
  * Introduced digest-based contract deployments with signature approval.
  * Added Tron blockchain deployment support.

* **Documentation**
  * Added comprehensive README files for Solidity and TypeScript packages.
  * Added contributing guidelines via AGENTS.md.

* **Infrastructure**
  * Restructured as monorepo with separate `solidity/` and `typescript/` directories.
  * Added GitHub Actions workflows for testing and coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->