### PR TITLE
(audit 6.4.8) Key validation logic uses bitwise `not()` where `iszero()` would be clearer

### DIFF
--- a/solidity/src/libs/KeyedOwnable.sol
+++ b/solidity/src/libs/KeyedOwnable.sol
@@ -146,14 +146,14 @@ contract KeyedOwnable {
                         // Check the upper 12 bytes
                         eq(shr(mul(8, 20), addr), 0),
                         // Check the lower 20 bytes
-                        not(eq(shl(mul(8, 12), addr), 0))
+                        iszero(eq(shl(mul(8, 12), addr), 0))
                     )
                 )
             }
             case 1 {
                 valid := and(
                     valid,
-                    not(
+                    iszero(
                         or(
                             // Check if first word of key is 0
                             eq(calldataload(key.offset), 0),
@@ -166,7 +166,7 @@ contract KeyedOwnable {
             case 2 {
                 valid := and(
                     valid,
-                    not(
+                    iszero(
                         or(
                             // Check if first word of key is 0
                             eq(calldataload(key.offset), 0),


### PR DESCRIPTION
Modify contracts to use `iszero` in 3 spots instead of `not` when the desired result is a boolean true or false.