### PR TITLE
(audit 6.4.4) Stale P256/WebAuthn key slot not cleared on ownership downgrade

### DIFF
--- a/solidity/src/libs/KeyedOwnable.sol
+++ b/solidity/src/libs/KeyedOwnable.sol
@@ -226,8 +226,9 @@ contract KeyedOwnable {
         // Use max(prevLen, 1) so we clear any extra slots from a prior P256/WebAuthn key.
         uint256 slotsToWrite = _keyTypeLength(publicKeyType);
         publicKeyType = PublicKeyType.ECDSAOrSmartContract;
-        for (uint256 i; i < slotsToWrite; ++i) {
-            _setPublicKeySlice(i, i == 0 ? bytes32(uint256(uint160(newOwner))) : bytes32(0));
+        _setPublicKeySlice(0, bytes32(uint256(uint160(newOwner))));
+        for (uint256 i = 1; i < slotsToWrite; ++i) {
+            _setPublicKeySlice(i, bytes32(0));
         }
 
         bytes32[] memory nextKeys = new bytes32[](1);

--- a/solidity/src/libs/KeyedOwnable.sol
+++ b/solidity/src/libs/KeyedOwnable.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import { DynamicArrayLib } from "solady/src/utils/DynamicArrayLib.sol";
 import { EfficientHashLib } from "solady/src/utils/EfficientHashLib.sol";
+import { FixedPointMathLib } from "solady/src/utils/FixedPointMathLib.sol";
 import { LibBit } from "solady/src/utils/LibBit.sol";
 import { LibBytes } from "solady/src/utils/LibBytes.sol";
 import { P256 } from "solady/src/utils/P256.sol";
@@ -191,8 +192,12 @@ contract KeyedOwnable {
         if (!_isValidKey(ktp, nextKey)) revert InvalidKey();
 
         uint256 nextKeyLength = nextKey.length;
-        for (uint256 i; i < nextKeyLength; ++i) {
-            _setPublicKeySlice(i, nextKey[i]);
+        // Use max(prevLen, nextLen) so we write every slot that either key occupies,
+        // clearing stale slots on downgrade without touching slots neither key uses.
+        uint256 slotsToWrite = _keyTypeLength(publicKeyType);
+        slotsToWrite = FixedPointMathLib.max(slotsToWrite, nextKeyLength);
+        for (uint256 i; i < slotsToWrite; ++i) {
+            _setPublicKeySlice(i, i < nextKeyLength ? nextKey[i] : bytes32(0));
         }
         publicKeyType = ktp;
         emit OwnershipTransferred(ktp, nextKey);
@@ -218,9 +223,12 @@ contract KeyedOwnable {
     function transferOwnership(
         address newOwner
     ) public payable onlyOwnerOrSelf {
-        // We set the keytype as smart contract
+        // Use max(prevLen, 1) so we clear any extra slots from a prior P256/WebAuthn key.
+        uint256 slotsToWrite = _keyTypeLength(publicKeyType);
         publicKeyType = PublicKeyType.ECDSAOrSmartContract;
-        _setPublicKeySlice(0, bytes32(uint256(uint160(newOwner))));
+        for (uint256 i; i < slotsToWrite; ++i) {
+            _setPublicKeySlice(i, i == 0 ? bytes32(uint256(uint160(newOwner))) : bytes32(0));
+        }
 
         bytes32[] memory nextKeys = new bytes32[](1);
         nextKeys[0] = bytes32(uint256(uint160(newOwner)));

--- a/solidity/test/libs/KeyedOwnable.t.sol
+++ b/solidity/test/libs/KeyedOwnable.t.sol
@@ -171,9 +171,37 @@ contract KeyedOwnableTest is P256VerifierEtcher {
         assertEq(uint8(ktp), uint8(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract));
         assertEq(key, expectedKey);
 
-        // Notice that we have a dirty slot now.
-        bytes32 dirtySlot = ownable.getPublicKeySlice(1);
-        assertNotEq(dirtySlot, 0);
+        // Slot 1 must be zeroed after downgrading from P256/WebAuthn to ECDSA.
+        bytes32 clearedSlot = ownable.getPublicKeySlice(1);
+        assertEq(clearedSlot, 0);
+    }
+
+    // Regression test: stale P256/WebAuthn key slot not cleared on ownership downgrade.
+    function test_transferOwnership_clearsStaleSlotOnDowngrade() external {
+        (, bytes32[] memory publickeyP256) = makeP256("P256Owner");
+
+        // Upgrade to P256 — writes slot 0 (x) and slot 1 (y).
+        vm.prank(address(ownable));
+        ownable.transferOwnership(KeyedOwnable.PublicKeyType.P256, publickeyP256);
+        assertNotEq(ownable.getPublicKeySlice(1), 0);
+
+        // Downgrade to ECDSA via transferOwnership(PublicKeyType, bytes32[]) — slot 1 must be zeroed.
+        bytes32[] memory ecdsaKey = new bytes32[](1);
+        ecdsaKey[0] = bytes32(uint256(uint160(makeAddr("ecdsaOwner"))));
+        vm.prank(address(ownable));
+        ownable.transferOwnership(KeyedOwnable.PublicKeyType.ECDSAOrSmartContract, ecdsaKey);
+        assertEq(ownable.getPublicKeySlice(1), 0, "slot 1 not cleared after downgrade via transferOwnership(ktp, key)");
+
+        // Upgrade to WebAuthn — writes slot 0 (x) and slot 1 (y).
+        (, bytes32[] memory publickeyWebAuthn) = makeP256("WebAuthnOwner");
+        vm.prank(address(ownable));
+        ownable.transferOwnership(KeyedOwnable.PublicKeyType.WebAuthnP256, publickeyWebAuthn);
+        assertNotEq(ownable.getPublicKeySlice(1), 0);
+
+        // Downgrade to ECDSA via transferOwnership(address) — slot 1 must be zeroed.
+        vm.prank(address(ownable));
+        ownable.transferOwnership(makeAddr("ecdsaOwner2"));
+        assertEq(ownable.getPublicKeySlice(1), 0, "slot 1 not cleared after downgrade via transferOwnership(address)");
     }
 
     function testRevert_transferOwnership_invalid_key() external {


### PR DESCRIPTION
Set excess ownership slots to 0