### PR TITLE
(audit 2) Redundant approve calls on already-maxed allowances waste gas

### DIFF
--- a/solidity/src/libs/IntentExecutor.sol
+++ b/solidity/src/libs/IntentExecutor.sol
@@ -12,8 +12,8 @@ import { SafeTransferLib } from "solady/src/utils/SafeTransferLib.sol";
 ///      Three-phase execution:
 ///      1. Safe approvals — safeApproveWithRetry(type(uint256).max) for each input token,
 ///         handling USDT-style tokens that revert on non-zero-to-non-zero approve.
-///         Max approval means subsequent executions with the same token+spender
-///         skip the storage write (~3-4k gas saved per repeat).
+///         Allowance is checked first; if already type(uint256).max the approve is skipped
+///         entirely (~1,800+ gas saved per repeat, avoiding the Approval event emission).
 ///      2. Call execution — arbitrary batched calls (swap, fee transfer, etc.)
 ///      3. Balance sweep — reads balanceOf(this) for each output token and transfers
 ///         the full remaining balance to the specified recipient.
@@ -120,14 +120,39 @@ contract IntentExecutor is ReentrancyGuard {
     /// @dev Safe max-approve each token to its spender.
     ///      Uses SafeTransferLib.safeApproveWithRetry which handles USDT-style tokens
     ///      by resetting to 0 first if needed.
-    ///      Max approval is a one-time storage write — subsequent calls with
-    ///      the same token+spender pair are a no-op read (~3-4k gas saved).
+    ///      Skips the approve entirely when allowance is already type(uint256).max,
+    ///      avoiding an unnecessary SSTORE + Approval event (~1,800+ gas per pair).
     function _safeApproveAll(
         Approval[] calldata approvals
     ) private {
         uint256 len = approvals.length;
         for (uint256 i = 0; i < len; ++i) {
-            SafeTransferLib.safeApproveWithRetry(approvals[i].token, approvals[i].spender, type(uint256).max);
+            address token = approvals[i].token;
+            address spender = approvals[i].spender;
+            if (_allowance(token, address(this), spender) < type(uint256).max) {
+                SafeTransferLib.safeApproveWithRetry(token, spender, type(uint256).max);
+            }
+        }
+    }
+
+    /// @dev Returns the ERC20 allowance of `owner` for `spender`. Returns 0 on failure.
+    /// This contract returns 0 if no contract has been deployed.
+    function _allowance(address token, address owner, address spender) private view returns (uint256 amount) {
+        assembly ("memory-safe") {
+            // Save free memory pointer. We will overwrite it.
+            let m := mload(0x40)
+            mstore(0x34, spender) // Spender zero-pad: 0x34-0x3f, address: 0x40-0x53 (corrupts free ptr temporarily).
+            mstore(0x14, owner) // Owner zero-pad: 0x14-0x1f, address: 0x20-0x33.
+            mstore(0x00, 0xdd62ed3e000000000000000000000000) // `allowance(address,address)` selector at 0x10.
+            amount :=
+                mul( // The arguments of `mul` are evaluated from right to left.
+                    mload(0x00),
+                    and( // The arguments of `and` are evaluated from right to left.
+                        gt(returndatasize(), 0x1f), // At least 32 bytes returned.
+                        staticcall(gas(), token, 0x10, 0x44, 0x00, 0x20)
+                    )
+                )
+            mstore(0x40, m) // Restore the free memory pointer.
         }
     }
 

--- a/solidity/test/libs/IntentExecutor.t.sol
+++ b/solidity/test/libs/IntentExecutor.t.sol
@@ -2,12 +2,24 @@
 pragma solidity ^0.8.17;
 
 import { Test } from "forge-std/src/Test.sol";
+import { VmSafe } from "forge-std/src/Vm.sol";
 
 import { MockERC20 } from "solady/test/utils/mocks/MockERC20.sol";
 
 import { IntentExecutor } from "../../src/libs/IntentExecutor.sol";
 
+/// @dev USDT-style token: reverts when approving a non-zero amount over an existing non-zero allowance.
+contract MockUSDT is MockERC20 {
+    constructor() MockERC20("Tether USD", "USDT", 6) { }
+
+    function approve(address spender, uint256 amount) public override returns (bool) {
+        if (amount > 0 && allowance(msg.sender, spender) > 0) revert("USDT: non-zero to non-zero");
+        return super.approve(spender, amount);
+    }
+}
+
 contract IntentExecutorTest is Test {
+    event Approval(address indexed owner, address indexed spender, uint256 amount);
     IntentExecutor executor;
     MockERC20 tokenA;
     MockERC20 tokenB;
@@ -291,6 +303,115 @@ contract IntentExecutorTest is Test {
     }
 
     // -- Approvals --
+
+    /// @dev Verify the guard skips approve entirely when allowance is already max.
+    /// The Approval event is the definitive proof — if it's not emitted, no approve call was made.
+    function test_approval_skipsApproveWhenAlreadyMax() external {
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](1);
+        approvals[0] = IntentExecutor.Approval({ token: address(tokenA), spender: address(this) });
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        // First call sets max allowance.
+        executor.executeAndSweep(approvals, calls, sweeps);
+        assertEq(tokenA.allowance(address(executor), address(this)), type(uint256).max);
+
+        // Second call: allowance already max — no Approval event should be emitted.
+        vm.recordLogs();
+        executor.executeAndSweep(approvals, calls, sweeps);
+        assertEq(vm.getRecordedLogs().length, 0);
+        assertEq(tokenA.allowance(address(executor), address(this)), type(uint256).max);
+    }
+
+    /// @dev Verify approve IS called when allowance is below max.
+    function test_approval_approvesWhenBelowMax() external {
+        address spender = address(this);
+
+        // Manually set a partial allowance on the executor.
+        vm.prank(address(executor));
+        tokenA.approve(spender, 1 ether);
+        assertEq(tokenA.allowance(address(executor), spender), 1 ether);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](1);
+        approvals[0] = IntentExecutor.Approval({ token: address(tokenA), spender: spender });
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        vm.expectEmit(true, true, false, true, address(tokenA));
+        emit Approval(address(executor), spender, type(uint256).max);
+        executor.executeAndSweep(approvals, calls, sweeps);
+
+        assertEq(tokenA.allowance(address(executor), spender), type(uint256).max);
+    }
+
+    /// @dev With multiple pairs in one call, only the pairs not already at max should approve.
+    function test_approval_multiPairs_onlyApprovesNonMax() external {
+        address spenderA = makeAddr("spenderA");
+        address spenderB = makeAddr("spenderB");
+
+        // Pre-approve spenderA to max; spenderB stays at zero.
+        vm.prank(address(executor));
+        tokenA.approve(spenderA, type(uint256).max);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](2);
+        approvals[0] = IntentExecutor.Approval({ token: address(tokenA), spender: spenderA });
+        approvals[1] = IntentExecutor.Approval({ token: address(tokenA), spender: spenderB });
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        // Only spenderB should trigger an Approval event.
+        vm.recordLogs();
+        executor.executeAndSweep(approvals, calls, sweeps);
+
+        VmSafe.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+        // The single Approval event must be for spenderB (topic[2] = spender).
+        assertEq(logs[0].topics[2], bytes32(uint256(uint160(spenderB))));
+
+        assertEq(tokenA.allowance(address(executor), spenderA), type(uint256).max);
+        assertEq(tokenA.allowance(address(executor), spenderB), type(uint256).max);
+    }
+
+    /// @dev USDT-style token: guard prevents the revert that would occur if approve were called
+    ///      over an existing non-zero allowance.
+    function test_approval_usdtStyle_skipsApproveWhenAlreadyMax() external {
+        MockUSDT usdt = new MockUSDT();
+        address spender = address(this);
+
+        // First call: sets max allowance via safeApproveWithRetry.
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](1);
+        approvals[0] = IntentExecutor.Approval({ token: address(usdt), spender: spender });
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        executor.executeAndSweep(approvals, calls, sweeps);
+        assertEq(usdt.allowance(address(executor), spender), type(uint256).max);
+
+        // Second call: guard skips approve entirely — USDT would revert if approve were called.
+        executor.executeAndSweep(approvals, calls, sweeps);
+        assertEq(usdt.allowance(address(executor), spender), type(uint256).max);
+    }
+
+    /// @dev USDT-style token with a partial allowance: safeApproveWithRetry must reset to 0
+    ///      before setting max. Guard correctly lets the call through when allowance < max.
+    function test_approval_usdtStyle_handlesPartialAllowance() external {
+        MockUSDT usdt = new MockUSDT();
+        address spender = address(this);
+
+        // Set a non-zero, non-max allowance directly on the executor.
+        vm.prank(address(executor));
+        usdt.approve(spender, 500e6);
+        assertEq(usdt.allowance(address(executor), spender), 500e6);
+
+        IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](1);
+        approvals[0] = IntentExecutor.Approval({ token: address(usdt), spender: spender });
+        IntentExecutor.Call3[] memory calls = new IntentExecutor.Call3[](0);
+        IntentExecutor.SweepTarget[] memory sweeps = new IntentExecutor.SweepTarget[](0);
+
+        // safeApproveWithRetry should reset to 0, then approve max.
+        executor.executeAndSweep(approvals, calls, sweeps);
+        assertEq(usdt.allowance(address(executor), spender), type(uint256).max);
+    }
 
     function test_approvalSetsMaxAllowance() external {
         IntentExecutor.Approval[] memory approvals = new IntentExecutor.Approval[](1);


### PR DESCRIPTION
Assembly read function for easily fetching remote approval value before calling approve.

To avoid having a breaking change, this code does not modify the approval structure with a token value to only call approve if less than that value.