### PR TITLE
Move Tron deploy script to typescript/ and refresh deployments

### DIFF
--- a/solidity/deployments/tron.json
+++ b/solidity/deployments/tron.json
@@ -1,5 +1,5 @@
 {
-  "CatapultarFactory": "TFDhmBmop6uDxbMutdJxnHX2a2s1zzr9sB",
-  "CATValidator": "TSUoeeGJVMKqKPhGtzqRfUDrfsprp1HPvo",
-  "IntentExecutor": "TMFkCV5D2UqbTWKhPbosN3zQq7Rs26Z9K8"
+  "CatapultarFactoryTron": "TFpA8oi5UYE7mMagAfK2BM6r78aE4jA2L8",
+  "CATValidatorTron": "TYjEq9DdArEAtsdRY9S65Y2GbqmM4myuzw",
+  "IntentExecutorTron": "TH5ysvD4VbUzKRQoFPXbMZpcetGcdHo2Q9"
 }

--- a/typescript/scripts/tron/deploy-catapultar.ts
+++ b/typescript/scripts/tron/deploy-catapultar.ts
@@ -1,8 +1,9 @@
 /**
- * Deploy Catapultar contracts to Tron.
+ * Deploy Catapultar Tron-variant contracts to Tron.
  *
- * Mirrors the Forge deploy.s.sol but uses TronWeb instead of CREATE2.
- * Deploy order: CatapultarFactory -> CATValidator -> IntentExecutor
+ * Only `.tron.sol` artifacts are deployed. Mirrors the Forge deploy.s.sol but
+ * uses TronWeb instead of CREATE2.
+ * Deploy order: CatapultarFactoryTron -> CATValidatorTron -> IntentExecutorTron
  *
  * Prerequisites:
  *   1. `cd catapultar/solidity && forge build`
@@ -11,15 +12,15 @@
  *      - RPC_URL_TRON (optional, defaults to https://api.trongrid.io)
  *      - TRONGRID_API_KEY (optional)
  *
- * Usage:
- *   bun run solidity/script/tron/deploy-catapultar.ts [--dry-run] [--testnet|--network tronshasta] [--private-key 0x...] [--rpc-url <url>] [--trongrid-api-key <key>]
+ * Usage (run from catapultar/typescript):
+ *   bun run scripts/tron/deploy-catapultar.ts [--dry-run] [--testnet|--network tronshasta] [--private-key 0x...] [--rpc-url <url>] [--trongrid-api-key <key>]
  *
  * Deploy only selected contracts (canonical order is always preserved):
- *   --step CatapultarFactory
- *   --step CATValidator
- *   --step IntentExecutor
- *   --step McopyTest   (not deployed by default)
- *   --step 1   (same as CatapultarFactory; 2 = CATValidator, 3 = IntentExecutor, 4 = McopyTest)
+ *   --step CatapultarFactoryTron
+ *   --step CATValidatorTron
+ *   --step IntentExecutorTron
+ *   --step McopyTestTron   (not deployed by default)
+ *   --step 1   (same as CatapultarFactoryTron; 2 = CATValidatorTron, 3 = IntentExecutorTron, 4 = McopyTestTron)
  *   Repeat --step to deploy a subset, e.g. --step 1 --step 3
  */
 
@@ -44,13 +45,31 @@ import {
 
 // ── Configuration ──────────────────────────────────────────────────────────────
 
-const ARTIFACTS_DIR = resolve(import.meta.dir, '../../out')
-const DEPLOYMENTS_FILE = resolve(import.meta.dir, '../../deployments/tron.json')
+const ARTIFACTS_DIR = resolve(import.meta.dir, '../../../solidity/out')
+const DEPLOYMENTS_FILE = resolve(
+  import.meta.dir,
+  '../../../solidity/deployments/tron.json'
+)
+
+/** Production contracts — deployed when no --step flags are provided. */
+const DEFAULT_CONTRACTS = [
+  'CatapultarFactoryTron',
+  'CATValidatorTron',
+  'IntentExecutorTron',
+] as const
+
+/** Opt-in contracts — only deployed when explicitly requested via --step. */
+const OPTIONAL_CONTRACTS = ['McopyTestTron'] as const
+
+/** Every contract selectable via --step. Must end in "Tron"; the source file is the name minus that suffix + ".tron.sol". */
+const ALL_CONTRACTS = [...DEFAULT_CONTRACTS, ...OPTIONAL_CONTRACTS] as const
+
+type DeployStepName = (typeof ALL_CONTRACTS)[number]
 
 async function loadTronArtifact(
-  contractName: string,
-  sourceFile: string
+  contractName: DeployStepName
 ): Promise<IForgeArtifact> {
+  const sourceFile = `${contractName.replace(/Tron$/, '')}.tron`
   const artifactPath = resolve(
     ARTIFACTS_DIR,
     `${sourceFile}.sol/${contractName}.json`
@@ -62,45 +81,6 @@ async function loadTronArtifact(
     )
   consola.info(`Loaded ${contractName} from: ${artifactPath}`)
   return artifact
-}
-
-/** All known contracts that can be deployed via --step. */
-const ALL_CONTRACTS = [
-  'CatapultarFactory',
-  'CATValidator',
-  'IntentExecutor',
-  'McopyTest',
-] as const
-
-type DeployStepName = (typeof ALL_CONTRACTS)[number]
-
-/** Contracts deployed by default (without --step). */
-const DEFAULT_CONTRACTS: readonly DeployStepName[] = [
-  'CatapultarFactory',
-  'CATValidator',
-  'IntentExecutor',
-]
-
-const TRON_CONTRACT: Record<
-  DeployStepName,
-  { contractName: string; sourceFile: string }
-> = {
-  CatapultarFactory: {
-    contractName: 'CatapultarFactoryTron',
-    sourceFile: 'CatapultarFactory.tron',
-  },
-  CATValidator: {
-    contractName: 'CATValidatorTron',
-    sourceFile: 'CATValidator.tron',
-  },
-  IntentExecutor: {
-    contractName: 'IntentExecutorTron',
-    sourceFile: 'IntentExecutor.tron',
-  },
-  McopyTest: {
-    contractName: 'McopyTestTron',
-    sourceFile: 'McopyTest.tron',
-  },
 }
 
 function resolveStepArg(raw: string): DeployStepName {
@@ -243,11 +223,10 @@ async function main() {
   }> = []
 
   for (const contractName of contractsToRun) {
-    const { contractName: tronName, sourceFile } = TRON_CONTRACT[contractName]
-    consola.info(`\n--- Deploying ${contractName} (${tronName}) ---`)
+    consola.info(`\n--- Deploying ${contractName} ---`)
 
     try {
-      const artifact = await loadTronArtifact(tronName, sourceFile)
+      const artifact = await loadTronArtifact(contractName)
       const result = await deployer.deployContract(artifact)
 
       results.push({ contract: contractName, result })


### PR DESCRIPTION
## Summary
- Relocates `deploy-catapultar.ts` from `solidity/script/tron/` to `typescript/scripts/tron/` so the deploy tooling lives next to the TypeScript library; artifact and deployments paths are repointed back into `solidity/`.
- Simplifies the `--step` selector to use the canonical `*Tron` contract names directly (drops the `TRON_CONTRACT` mapping; source file is derived as `<name without 'Tron'>.tron.sol`).
- Records freshly deployed mainnet addresses in `solidity/deployments/tron.json` (keys now match the `*Tron` contract names).

New mainnet addresses:
- `CatapultarFactoryTron`: `TFpA8oi5UYE7mMagAfK2BM6r78aE4jA2L8`
- `CATValidatorTron`: `TYjEq9DdArEAtsdRY9S65Y2GbqmM4myuzw`
- `IntentExecutorTron`: `TH5ysvD4VbUzKRQoFPXbMZpcetGcdHo2Q9`

## Test plan
- [x] `cd catapultar/solidity && forge build` succeeds — built with only pre-existing `unchecked-call` lint warnings; no errors.
- [x] `cd catapultar/typescript && bun run scripts/tron/deploy-catapultar.ts --dry-run` deploys all 3 default contracts — script iterates `CatapultarFactoryTron → CATValidatorTron → IntentExecutorTron` from the relocated `../../../solidity/out` artifacts and exits successfully. (Locally also verified end-to-end via the deployer-account dry-run earlier in the working session, which produced the full "DRY RUN - Simulated deployment" output for all 3.)
- [x] `bun run scripts/tron/deploy-catapultar.ts --step CATValidatorTron --dry-run` deploys a single step — only `CATValidatorTron` is selected and processed; summary line confirms `Selected contract(s) deployed successfully!`.
- [x] Verify `solidity/deployments/tron.json` is written with the `*Tron` keys after a real deploy — file on disk contains the new `CatapultarFactoryTron` / `CATValidatorTron` / `IntentExecutorTron` keys mapped to the addresses above, written by the real deploys at `41e5d62b...`, `c69f32a0...`, `0040a6a8...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)