### PR TITLE
[API-679] ci: add Zeus QA review dispatch workflow

### DIFF
--- a/.github/workflows/qa-review-dispatch.yml
+++ b/.github/workflows/qa-review-dispatch.yml
@@ -1,0 +1,64 @@
+name: Trigger Zeus QA Review
+
+on:
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  group: qa-review-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    if: github.event.label.name == 'Agent Review Request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.QA_APP_ID }}
+          private-key: ${{ secrets.QA_APP_PRIVATE_KEY }}
+          owner: lifinance
+
+      - name: Swap labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --method DELETE "repos/$REPO/issues/$PR_NUMBER/labels/Agent%20Review%20Request" || true
+          gh api --method DELETE "repos/$REPO/issues/$PR_NUMBER/labels/QA%20AI%20Approved" || true
+          if ! gh api --method POST "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --field "labels[]=QA AI Reviewing"; then
+            echo "❌ Failed to apply QA AI Reviewing label — aborting"
+            exit 1
+          fi
+
+      - name: Dispatch to QA repo
+        id: dispatch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh api repos/lifinance/QA/actions/workflows/qa-run.yml/dispatches \
+            --method POST \
+            --field ref=main \
+            --field "inputs[scenario]=QAReviewIntents.md" \
+            --field "inputs[agent]=zeus" \
+            --field "inputs[ticket]=$PR_URL"
+
+      - name: Restore labels on dispatch failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --method DELETE "repos/$REPO/issues/$PR_NUMBER/labels/QA%20AI%20Reviewing" || true
+          gh api --method POST "repos/$REPO/issues/$PR_NUMBER/labels" \
+            --field "labels[]=Agent Review Request" || true
+          echo "⚠️ Dispatch failed — restored Agent Review Request label"


### PR DESCRIPTION
## Summary

- Adds the Zeus QA review dispatch workflow so catapultar PRs can be QA-reviewed on demand, same as the other intents repos. Labelling a PR with `Agent Review Request` swaps it to `QA AI Reviewing` and dispatches `qa-run.yml` in `lifinance/QA` (agent `zeus`, scenario `QAReviewIntents.md`, targeted at the PR URL); labels are restored if the dispatch fails.
- The file is a byte-identical copy of the canonical `qa-review-dispatch.yml` already running in `lifi-order-service`, `lifi-solver`, and `lifi-wallet-service` — catapultar becomes the fourth repo in the fleet.
- The required QA labels (`Agent Review Request`, `QA AI Reviewing`, `QA AI Approved`) already exist on this repo, matching lifi-order-service.
- Linear ticket: https://linear.app/lifi-linear/issue/API-679/add-zeus-qa-review-dispatch-workflow-to-lifinancecatapultar (config registration on the QA side: QA-146 / lifinance/QA#152)

## Dependencies

- ⚠️ Repo-level secrets `QA_APP_ID` and `QA_APP_PRIVATE_KEY` must be added to this repo by an org admin before the dispatch can succeed (they exist in the three sibling repos but are missing here). Until then, labelling a PR fails the workflow gracefully and restores the `Agent Review Request` label.

## How to validate

- [ ] Confirm the workflow file matches `lifi-order-service/.github/workflows/qa-review-dispatch.yml` byte-for-byte
- [ ] After the secrets are added: label a small open PR with `Agent Review Request`
- [ ] Verify labels swap to `QA AI Reviewing` and a `qa-run.yml` run starts in `lifinance/QA` with `scenario=QAReviewIntents.md` and the PR URL as ticket
- [ ] Verify the Zeus review report is posted back on the PR
